### PR TITLE
⚡️[PIPE-549] Change config format to be TOML

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -1,6 +1,6 @@
 pkgs: configContent: prefix: { key, structure }:
 let
-  parsedConfig = builtins.fromJSON configContent;
+  parsedConfig = builtins.fromTOML configContent;
   subConfig = (if builtins.hasAttr key parsedConfig then builtins.getAttr key parsedConfig else {});
 in
   with builtins;


### PR DESCRIPTION
TOML is easier to parse as a human and easier to write (less strange
rules about quoting and commas). Since nix has a builtin for parsing
TOML, this change is very minimal.