### PR TITLE
🐛 Fix shellHook protobuf location

### DIFF
--- a/mkcomponent.nix
+++ b/mkcomponent.nix
@@ -8,7 +8,7 @@ let
       PROTOBUF_DEFINITIONS_LOCATION = protoLocation;
       shellHook = ''
         ${oldAttrs.shellHook or ""}
-        export PROTOBUF_DEFINITIONS_LOCATION=${protoLocation}
+        export PROTOBUF_DEFINITIONS_LOCATION=${builtins.toString protoLocation}
       '';
     }
   );


### PR DESCRIPTION
Needs to be converted to a string to not mean to Nix that it should copy
it out to another folder and refer to that instead. Doing so, weould
defeat the purpose of the shell hook which is to pick up changes in the
protobuf files "live".