### PR TITLE
👷 Add rust cache location defaults

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,7 +1,7 @@
 import (
   builtins.fetchGit {
-    name = "nixpackages-20.03-beta";
+    name = "nixpackages-20.03";
     url = "https://github.com/NixOS/nixpkgs.git";
-    ref = "refs/tags/20.03-beta"; # pinned because of https://github.com/NixOS/nixpkgs/issues/75941
+    ref = "refs/tags/20.03";
   }
 )


### PR DESCRIPTION
There are two fallbacks. Worst case it will use the temp folder which
works but might not be optimal since the tmp might all be in
RAM. There is a warning and instructions telling the user what to do
in that case so that's fine.