### PR TITLE
🐛 Fix rust components being created twice

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -1,16 +1,15 @@
 pkgs: configContent: prefix: { key, structure }:
 let
   parsedConfig = builtins.fromTOML configContent;
-  subConfig = (if builtins.hasAttr key parsedConfig then builtins.getAttr key parsedConfig else {});
+  subConfig = ( if builtins.hasAttr key parsedConfig then builtins.getAttr key parsedConfig else { });
 in
-  with builtins;
-  pkgs.lib.mapAttrsRecursiveCond
-    (a: isAttrs a)
-    (
-      path: value:
-        let
-          envVarValue = getEnv "${prefix}_${key}_${concatStringsSep "_" path}";
-        in
-          if envVarValue != "" then envVarValue else (pkgs.lib.attrByPath path value subConfig)
-    )
-    structure
+with builtins;
+pkgs.lib.mapAttrsRecursiveCond
+  (a: isAttrs a)
+  (
+    path: value:
+      let
+        envVarValue = getEnv "${prefix}_${key}_${concatStringsSep "_" path}";
+      in if envVarValue != "" then envVarValue else (pkgs.lib.attrByPath path value subConfig)
+  )
+  structure

--- a/default.nix
+++ b/default.nix
@@ -12,90 +12,95 @@ let
     };
 in
 rec {
-  getDeployments = { components, type }: builtins.map (c: c.derivation or {}) (
-    builtins.filter (c: c.type or "" == type) (
-      pkgs.lib.flatten (
-        builtins.map (c: (builtins.attrValues c.deployment)) (
-          builtins.filter (c: builtins.hasAttr "deployment" c) (builtins.attrValues components)
+  getDeployments = { components, type }: builtins.map (c: c.derivation or { })
+    (
+      builtins.filter (c: c.type or "" == type)
+        (
+          pkgs.lib.flatten
+            (
+              builtins.map (c: (builtins.attrValues c.deployment))
+                (
+                  builtins.filter (c: builtins.hasAttr "deployment" c) (builtins.attrValues components)
+                )
+            )
         )
-      )
-    )
-  );
+    );
 
   # import another nedryland project
   importProject = { name, url, rev ? null, ref ? "master", pathOverrideEnvVar ? "${pkgs.lib.toUpper name}_PATH" }:
-    import (
-      if builtins.getEnv pathOverrideEnvVar != "" then
-        (./. + "/${builtins.getEnv pathOverrideEnvVar}/project.nix")
-      else
-        builtins.fetchGit {
-          inherit name url rev ref;
-        } + "/project.nix"
-    );
-
-  mkProject = { name, configFile, baseExtensions ? [], projectDependencies ? [] }:
-    let
-      configContentFromEnv = builtins.getEnv "${pkgs.lib.toUpper name}_config";
-      configContent = if configContentFromEnv != "" then configContentFromEnv else (
-        if builtins.pathExists configFile then builtins.readFile configFile else "{}"
+    import
+      (
+        if builtins.getEnv pathOverrideEnvVar != "" then
+          (./. + "/${builtins.getEnv pathOverrideEnvVar}/project.nix")
+        else
+          builtins.fetchGit {
+            inherit name url rev ref;
+          } + "/project.nix"
       );
 
+  mkProject = { name, configFile, baseExtensions ? [ ], projectDependencies ? [ ] }:
+    let
+      configContentFromEnv = builtins.getEnv "${pkgs.lib.toUpper name}_config";
+      configContent =
+        if configContentFromEnv != "" then configContentFromEnv else ( if builtins.pathExists configFile then builtins.readFile configFile else "{}"
+        );
       base = {
         mkComponent = import ./mkcomponent.nix pkgs;
         mkClient = import ./mkclient.nix base;
         mkService = import ./mkservice.nix base;
-        extend = pkgs.callPackage ./extend.nix {};
-        deployment = pkgs.callPackage ./deployment.nix {};
+        extend = pkgs.callPackage ./extend.nix { };
+        deployment = pkgs.callPackage ./deployment.nix { };
         theme = import ./theme/default.nix pkgs;
         parseConfig = import ./config.nix pkgs configContent (pkgs.lib.toUpper name);
         languages = pkgs.callPackage ./languages { inherit base; };
       };
-
       allBaseExtensions = (
-        builtins.foldl' (x: y: x ++ y) [] (
-          builtins.map (pd: pd.baseExtensions) projectDependencies
-        )
+        builtins.foldl' (x: y: x ++ y) [ ]
+          (
+            builtins.map (pd: pd.baseExtensions) projectDependencies
+          )
       ) ++ baseExtensions;
-
-      combinedBaseExtensions = builtins.foldl' (
-        left: right: pkgs.lib.recursiveUpdate left (right { inherit base pkgs; })
-      ) {} allBaseExtensions;
-
+      combinedBaseExtensions = builtins.foldl'
+        (
+          left: right: pkgs.lib.recursiveUpdate left (right { inherit base pkgs; })
+        ) { } allBaseExtensions;
       extendedBase = pkgs.lib.recursiveUpdate combinedBaseExtensions base;
     in
-      {
-        declareComponent = path: dependencies@{ ... }:
-          let
-            c = pkgs.callPackage path ({ base = extendedBase; } // dependencies);
-          in
-            c // {
-              inherit path;
-              packageWithChecks = c.package.overrideAttrs (
-                oldAttrs: {
-                  doCheck = true;
-                }
+    {
+      declareComponent = path: dependencies@{ ... }:
+        let
+          c = pkgs.callPackage path ({ base = extendedBase; } // dependencies);
+        in
+        c // {
+          inherit path;
+          packageWithChecks = c.package.overrideAttrs
+            (
+              oldAttrs: {
+                doCheck = true;
+              }
+            );
+        };
+
+      mkGrid = { components, deploy, extraShells ? { }, lib ? { } }:
+        let
+          allComponents = (builtins.attrValues components);
+        in
+        {
+          inherit baseExtensions lib;
+          grid = rec {
+            inherit deploy;
+
+            package = builtins.map (component: component.package) allComponents;
+            packageWithChecks = builtins.map (component: component.packageWithChecks) allComponents;
+            deploymentConfigs = builtins.filter (c: c != null)
+              (builtins.map (component: component.deployment) allComponents);
+            docs = pkgs.lib.foldl (x: y: x // y) { }
+              (
+                builtins.filter (d: d != { } && d != null)
+                  (builtins.map (component: component.docs) allComponents)
               );
-            };
-
-        mkGrid = { components, deploy, extraShells ? {}, lib ? {} }:
-          let
-            allComponents = (builtins.attrValues components);
-          in
-            {
-              inherit baseExtensions lib;
-              grid = rec {
-                inherit deploy;
-
-                package = builtins.map (component: component.package) allComponents;
-                packageWithChecks = builtins.map (component: component.packageWithChecks) allComponents;
-                deploymentConfigs = builtins.filter (c: c != null)
-                  (builtins.map (component: component.deployment) allComponents);
-                docs = pkgs.lib.foldl (x: y: x // y) {} (
-                  builtins.filter (d: d != {} && d != null)
-                    (builtins.map (component: component.docs) allComponents)
-                );
-              } // components;
-              shells = pkgs.callPackage ./shell.nix { inherit components extraShells; };
-            };
-      };
+          } // components;
+          shells = pkgs.callPackage ./shell.nix { inherit components extraShells; };
+        };
+    };
 }

--- a/deployment.nix
+++ b/deployment.nix
@@ -8,7 +8,7 @@ in
   mkK8sConfig = k8sFunctions.dynamic;
   mkDatabaseConfig = import ./configs/databaseconfig.nix;
   mkDeploymentConfig = import ./configs/deploymentconfig.nix;
-  mkWindowsInstaller = {}: {};
-  mkRPMPackage = {}: {};
-  uploadFiles = files: {};
+  mkWindowsInstaller = {}: { };
+  mkRPMPackage = {}: { };
+  uploadFiles = files: { };
 }

--- a/extend.nix
+++ b/extend.nix
@@ -9,7 +9,7 @@
     };
   };
 
-  mkExtension = { componentTypes ? {}, deployFunctions ? {}, languages ? {} }:
+  mkExtension = { componentTypes ? { }, deployFunctions ? { }, languages ? { } }:
     componentTypes // (
       {
         deployment = deployFunctions;

--- a/mkclient.nix
+++ b/mkclient.nix
@@ -1,2 +1,2 @@
-base: { name, package, deployment }:
-base.mkComponent { inherit package deployment; }
+base: attrs@{ name, package, deployment, ... }:
+base.mkComponent attrs

--- a/mkcomponent.nix
+++ b/mkcomponent.nix
@@ -1,11 +1,18 @@
-pkgs: { package, deployment ? {}, docs ? null, usesProtobuf ? true }:
+pkgs: attrs@{ package, deployment ? { }, docs ? null, usesProtobuf ? true, ... }:
 let
-  packageWithProto = package.overrideAttrs (
-    oldAttrs: {
-      # this is needed on NixOS but does not hurt on other
-      # OSes either
-      PROTOC = "${pkgs.protobuf}/bin/protoc";
+  packageWithProto = package.overrideAttrs
+    (
+      oldAttrs: {
+        # this is needed on NixOS but does not hurt on other
+        # OSes either
+        PROTOC = "${pkgs.protobuf}/bin/protoc";
+      }
+    );
+  comp = (
+    attrs // {
+      package = if usesProtobuf then packageWithProto else package;
+      inherit deployment docs;
     }
   );
 in
-rec { package = if usesProtobuf then packageWithProto else package; inherit deployment docs; }
+comp

--- a/mkservice.nix
+++ b/mkservice.nix
@@ -1,2 +1,2 @@
-base: { name, package, deployment }:
-base.mkComponent { inherit package deployment; }
+base: attrs@{ name, package, deployment, ... }:
+base.mkComponent attrs

--- a/shell.nix
+++ b/shell.nix
@@ -1,24 +1,26 @@
-{ pkgs, components, extraShells ? {} }:
+{ pkgs, components, extraShells ? { } }:
 let
   all = pkgs.mkShell {
     buildInputs = builtins.map (c: c.package) (builtins.attrValues components);
   };
 in
-builtins.mapAttrs (
-  name: component:
-    (
-      component.package.overrideAttrs (
-        oldAttrs: {
-          shellHook = ''
-            echo 🏗️ Changing dir to \"${builtins.dirOf (builtins.toString component.path)}\"
-            cd ${builtins.dirOf (builtins.toString component.path)}
-            echo 🐚 Running shell hook for \"${name}\"
-            ${oldAttrs.shellHook}
-            echo 🥂 You are now in a shell for working on \"${name}\"
-          '';
-        }
+builtins.mapAttrs
+  (
+    name: component:
+      (
+        component.package.overrideAttrs
+          (
+            oldAttrs: {
+              shellHook = ''
+                echo 🏗️ Changing dir to \"${builtins.dirOf (builtins.toString component.path)}\"
+                cd ${builtins.dirOf (builtins.toString component.path)}
+                echo 🐚 Running shell hook for \"${name}\"
+                ${oldAttrs.shellHook}
+                echo 🥂 You are now in a shell for working on \"${name}\"
+              '';
+            }
+          )
       )
-    )
-) components // extraShells // {
+  ) components // extraShells // {
   inherit all;
 }

--- a/utils/build-static-nginx.nix
+++ b/utils/build-static-nginx.nix
@@ -12,23 +12,27 @@ let
       server {
         listen 80;
         index index.html;
-        ${builtins.concatStringsSep "\n" (
-    pkgs.lib.reverseList (
-      pkgs.lib.mapAttrsToList (
-        location: attrs: ''
-          location ${location} {
-            ${if attrs ? root then "root ${attrs.root};" else ""}
-            ${if attrs ? alias then "alias ${attrs.alias};" else ""}
-            ${if attrs ? redirectTo then "return 301 ${attrs.redirectTo};" else ""}
-            ${if (attrs.redirectToIndex or false) then ''
-          try_files $uri $uri/ /index.html;
-        '' else ""}
-            autoindex ${if (attrs.directoryListing or false) then "on" else "off"};
-          }
-        ''
-      ) locations
-    )
-  )}
+        ${builtins.concatStringsSep "\n"
+      (
+          pkgs.lib.reverseList
+              (
+                  pkgs.lib.mapAttrsToList
+                      (
+                          location: attrs: ''
+                              location ${location} {
+                                ${ if attrs ? root then "root ${attrs.root};" else ""}
+                                ${ if attrs ? alias then "alias ${attrs.alias};" else ""}
+                                ${ if attrs ? redirectTo then "return 301 ${attrs.redirectTo};" else ""}
+                                ${
+                              if (attrs.redirectToIndex or false) then ''
+                                try_files $uri $uri/ /index.html;
+                              '' else ""}
+                                autoindex ${ if (attrs.directoryListing or false) then "on" else "off"};
+                              }
+                            ''
+                        ) locations
+                )
+        )}
       }
     }
   '';


### PR DESCRIPTION
Rust components were created twice, the second time with way less
arguments, causing us to lose properties that we thought were set.