### PR TITLE
⚡️ Fix overridePath and remove hasTests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ rec {
     import
       (
         if builtins.getEnv pathOverrideEnvVar != "" then
-          (./. + "/${builtins.getEnv pathOverrideEnvVar}/project.nix")
+          (builtins.getEnv "PWD" + "/${builtins.getEnv pathOverrideEnvVar}/project.nix")
         else
           builtins.fetchGit {
             inherit name url rev ref;

--- a/languages/rust/component.nix
+++ b/languages/rust/component.nix
@@ -3,7 +3,6 @@ pkgs: base: { name
             , buildInputs ? [ ]
             , extensions ? [ ]
             , targets ? [ ]
-            , hasTests ? true
             , rustDependencies ? [ ]
             , defaultTarget ? ""
             , useNightly ? ""
@@ -137,7 +136,7 @@ pkgs.stdenv.mkDerivation
 
       checkPhase = ''
         cargo fmt -- --check
-        ${ if hasTests then "cargo test" else ""}
+        cargo test
         cargo clippy
       '';
 


### PR DESCRIPTION
Rust functions now have tests. Also, fix the override path variable for
project imports to actually use PWD instead of `./.` which would be
relative to the path to Nedryland (usually inside /nix/store so not very
useful) instead of relative to the current working directory as you
would expect.