### PR TITLE
✨ [PIPE-970] [PIPE-981] Add python language helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Added python language helper for utility libraries (base.languages.python.mkUtility)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @abbec @sakarias88 @simonrainerson

--- a/default.nix
+++ b/default.nix
@@ -27,7 +27,8 @@ rec {
     let
       configContentFromEnv = builtins.getEnv "${pkgs.lib.toUpper name}_config";
       configContent =
-        if configContentFromEnv != "" then configContentFromEnv else (if builtins.pathExists configFile then builtins.readFile configFile else "{}"
+        if configContentFromEnv != "" then configContentFromEnv else (
+          if builtins.pathExists configFile then builtins.readFile configFile else "{}"
         );
       base = {
         mkComponent = import ./mkcomponent.nix pkgs;
@@ -65,6 +66,9 @@ rec {
             c.package.overrideAttrs (
               oldAttrs: {
                 doCheck = true;
+
+                # Python packages don't have a checkPhase, only an installCheckPhase
+                doInstallCheck = true;
               }
             );
         };

--- a/extend.nix
+++ b/extend.nix
@@ -3,17 +3,10 @@
     "mk${pkgs.lib.toUpper (builtins.substring 0 1 name)}${builtins.substring 1 (builtins.stringLength name) name}" = createFunction;
   };
 
-  mkLanguageHelper = { language, functions }: {
-    languages = {
-      "${language}" = functions;
-    };
-  };
-
   mkExtension = { componentTypes ? { }, deployFunctions ? { }, languages ? { } }:
-    componentTypes // (
-      {
-        deployment = deployFunctions;
-      }
-    ) // languages;
-
+    componentTypes
+    // {
+      deployment = deployFunctions;
+      inherit languages;
+    };
 }

--- a/languages/default.nix
+++ b/languages/default.nix
@@ -1,2 +1,5 @@
 { base, pkgs }:
-{ rust = pkgs.callPackage ./rust { inherit base; }; }
+{
+  rust = pkgs.callPackage ./rust { inherit base; };
+  python = pkgs.callPackage ./python { inherit base; };
+}

--- a/languages/python/default.nix
+++ b/languages/python/default.nix
@@ -1,0 +1,39 @@
+{ base, pkgs }:
+rec {
+  mkPackage = import ./package.nix pkgs base;
+  mkUtility =
+    { name
+    , version
+    , src
+    , pythonVersion
+    , checkInputs ? (pythonPkgs: [ ])
+    , buildInputs ? (pythonPkgs: [ ])
+    , nativeBuildInputs ? (pythonPkgs: [ ])
+    , propagatedBuildInputs ? (pythonPkgs: [ ])
+    , preBuild ? ""
+    }:
+    let
+      package = mkPackage { inherit name version pythonVersion checkInputs buildInputs nativeBuildInputs propagatedBuildInputs preBuild src; };
+
+      packageWithWheel = package // {
+        wheel = pythonVersion.pkgs.buildPythonPackage {
+          pname = "${name}-wheel";
+          format = "other";
+
+          inherit src;
+
+          buildPhase = ''
+            ${pythonVersion} setup.py bdist_wheel
+          '';
+
+          installPhase = ''
+            mkdir -p $out
+            cp dist/*.whl $out/
+          '';
+        };
+      };
+    in
+    base.mkComponent {
+      package = packageWithWheel;
+    };
+}

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -1,0 +1,121 @@
+pkgs: base: { name, version, src, pythonVersion, checkInputs, buildInputs, nativeBuildInputs, propagatedBuildInputs, preBuild ? "", format ? "setuptools" }:
+let
+  pythonPkgs = pythonVersion.pkgs;
+
+  commands = ''
+    test() {
+        eval "$installCheckPhase"
+    }
+  '';
+
+  extendFile = { src, filePath, baseFile, name }:
+    pkgs.stdenv.mkDerivation {
+      name = "pyconfig-${builtins.baseNameOf filePath}";
+      builder = builtins.toFile "builder.sh" ''
+        source $stdenv/setup
+        mkdir -p $out/${builtins.dirOf filePath}
+
+        if [ ! -f ${src}/${filePath} ]; then
+        echo "Using default \"${filePath}\" because there is no \"${filePath}\" in the source"
+        cp ${baseFile} $out/${filePath}
+        chmod +w $out/${filePath}
+
+        if [ -f ${src}/${filePath}.include ]; then
+            echo "Including \"${filePath}.include\" in \"${filePath}\""
+            echo "" >> $out/${filePath}
+            echo "# from ${name}'s ${filePath}.include" >> $out/${filePath}
+            cat ${src}/${filePath}.include >> $out/${filePath}
+        fi
+        chmod -w $out/${filePath}
+        else
+        echo "Using ${name}'s ${filePath} since it exists in the source"
+        cp ${src}/${filePath} $out/${filePath}
+        fi
+      '';
+    };
+
+  setupCfg = ''${extendFile {
+      filePath = "setup.cfg";
+      baseFile = ./setup.cfg;
+      inherit name src;
+      }}/setup.cfg'';
+
+  pylintrc = ''
+    ${extendFile {
+      filePath = "pylintrc";
+      baseFile = ./pylintrc;
+      inherit name src;
+      }}/pylintrc
+  '';
+in
+pythonPkgs.buildPythonPackage {
+  inherit version src setupCfg pylintrc format preBuild;
+  pname = name;
+
+  # Dependencies needed for running the checkPhase. These are added to nativeBuildInputs when doCheck = true. Items listed in tests_require go here.
+  checkInputs = with pythonPkgs; [
+    black
+    flake8
+    isort
+    pylint
+
+    pytest
+    pytest-pylint
+    pytest-black
+    pytest-mypy
+    pytest-flake8
+    pytest-isort
+
+    python-language-server
+    pyls-mypy
+    pyls-isort
+  ] ++ checkInputs pythonPkgs;
+
+  # Build and/or run-time dependencies that need to be be compiled
+  # for the host machine. Typically non-Python libraries which are being linked.
+  buildInputs = buildInputs pythonPkgs;
+
+  # Build-time only dependencies. Typically executables as well
+  # as the items listed in setup_requires
+  nativeBuildInputs = nativeBuildInputs pythonPkgs;
+
+  # Aside from propagating dependencies, buildPythonPackage also injects
+  # code into and wraps executables with the paths included in this list.
+  # Items listed in install_requires go here
+  propagatedBuildInputs = propagatedBuildInputs pythonPkgs;
+
+  doCheck = false;
+
+  configurePhase = ''
+    rm -f setup.cfg
+    rm -f .pylintrc
+    ln -s $setupCfg setup.cfg
+    ln -s $pylintrc .pylintrc
+  '';
+
+  checkPhase = ''
+    echo "Running pytest (with pylint, flake8, mypy, isort and black) 🧪"
+    pytest --pylint --black --mypy --flake8 --isort ./
+  '';
+
+  shellInputs = [ ];
+
+  shellHook = ''
+    if [ -L setup.cfg ]; then
+       unlink setup.cfg
+    fi
+
+    if [ ! -f setup.cfg ]; then
+       ln -s $setupCfg setup.cfg
+    fi
+
+    if [ -L .pylintrc ]; then
+       unlink .pylintrc
+    fi
+
+    if [ ! -f .pylintrc ]; then
+       ln -s $pylintrc .pylintrc
+    fi
+    ${commands}
+  '';
+}

--- a/languages/python/pylintrc
+++ b/languages/python/pylintrc
@@ -1,0 +1,583 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# DO NOT WRITE IN MY HOME FOLDER!
+persistent=no
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=no-member,
+        print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        C0330,
+        fixme
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, `new` is for `{}` formatting,and `fstr` is for f-strings.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/languages/python/setup.cfg
+++ b/languages/python/setup.cfg
@@ -1,0 +1,26 @@
+[flake8]
+max-line-length = 88
+
+[pycodestyle]
+max-line-length = 88
+
+[tool:pytest]
+addopts = -p no:warnings
+
+[mypy]
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+
+[mypy-grpc]
+ignore_missing_imports = True
+
+[mypy-pytest]
+ignore_missing_imports = True
+
+[mypy-setuptools]
+ignore_missing_imports = True
+
+# ignore all errors for proto-generated files
+[mypy-gbk_protocols.*]
+ignore_missing_imports = True
+ignore_errors = True

--- a/shell.nix
+++ b/shell.nix
@@ -4,8 +4,8 @@ let
     let
       comp = if (builtins.isFunction components) then (components { }) else components;
     in
-    [ ] ++
-    (
+    [ ]
+    ++ (
       if builtins.hasAttr "package" comp then
         [ comp.package ]
       else
@@ -22,10 +22,10 @@ builtins.mapAttrs
     name: component:
       (
         let
-          pkg = component.package;
+          pkg = component.packageWithChecks;
           shellPkg = pkg.drvAttrs // {
             name = "${pkg.name}-shell";
-            buildInputs = (pkg.shellInputs or [ ]) ++ (pkg.buildInputs  or [ ]);
+            nativeBuildInputs = (pkg.shellInputs or [ ]) ++ (pkg.nativeBuildInputs or [ ]);
             shellHook = ''
               echo 🏗️ Changing dir to \"${builtins.dirOf (builtins.toString component.path)}\"
               cd ${builtins.dirOf (builtins.toString component.path)}


### PR DESCRIPTION
- added mkUtility for python utility libraries
    - mkUtility gets an extra "wheel" package for being used later in bundling
- added low level python mkPackage
    - Provide setup.cfg by default by linking it to the component dir.
    Users can add a setup.cfg.include in order to add extra. They can also
    specify their own setup.cfg if they do not want the provided default
    behaviour.
    - Provide .pylintrc by default by linking it to the component dir.
    Users can add a .pylintrc.include in order to add extra. They can also
    specify their own .pylintrc if they do not want the provided default
    behaviour.
    - Add test command which will run pytest with pylint, mypy, flake8, isort
    and black.