### PR TITLE
🐛 Base extensions in dependant projects get combined base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Base extensions in dependant projects get combined base
+
+
 ## [0.3.0] - 2020-07-23
 ### Added
 - Added python language helper for utility libraries (base.languages.python.mkUtility)

--- a/default.nix
+++ b/default.nix
@@ -49,7 +49,8 @@ rec {
       ) ++ baseExtensions;
       combinedBaseExtensions = builtins.foldl'
         (
-          left: right: pkgs.lib.recursiveUpdate left (right { inherit base pkgs; })
+          # Combine all extensions into one dictionary that we can merge with base
+          combinedBaseExtensions: currentBaseExtension: pkgs.lib.recursiveUpdate combinedBaseExtensions (currentBaseExtension { base = (pkgs.lib.recursiveUpdate combinedBaseExtensions base); inherit pkgs; })
         )
         { }
         allBaseExtensions;


### PR DESCRIPTION
- Before they would only get a clean base from nedryland and not any
projects they depended on.