### PR TITLE
⚡️ Build wheel as separate derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- All python utilities now have wheels built as a separate derivation that then gets "linked" to the
+  original derivation via a file in "$pkg/nedryland/wheels".
 
 ## [0.4.1] - 2020-07-23
 ### Fixed

--- a/languages/python/default.nix
+++ b/languages/python/default.nix
@@ -14,25 +14,52 @@ rec {
     , doStandardTests ? true
     }:
     let
-      package = mkPackage { inherit name version pythonVersion checkInputs buildInputs nativeBuildInputs propagatedBuildInputs preBuild src doStandardTests; };
-
-      packageWithWheel = package // {
-        wheel = pythonVersion.pkgs.buildPythonPackage {
-          pname = "${name}-wheel";
-          format = "other";
-
-          inherit src;
-
-          buildPhase = ''
-            ${pythonVersion} setup.py bdist_wheel
-          '';
-
-          installPhase = ''
-            mkdir -p $out
-            cp dist/*.whl $out/
-          '';
-        };
+      package = mkPackage {
+        inherit
+          name
+          version
+          pythonVersion
+          checkInputs
+          buildInputs
+          nativeBuildInputs
+          propagatedBuildInputs
+          preBuild
+          src
+          doStandardTests;
       };
+
+      wheel = package.overrideAttrs (oldAttrs: {
+        name = "${oldAttrs.name}-wheel";
+        format = "other";
+
+        nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
+          pythonVersion.pkgs.wheel
+          pythonVersion.pkgs.pip
+        ];
+
+        # TODO: this currently builds a wheel for the host platform,
+        # not the target one if that is needed. Building for the host platform
+        # works well enough for python-only wheels.
+        buildPhase = ''
+          eval "$preBuild"
+          ${oldAttrs.buildPhase or ""}
+          python setup.py bdist_wheel || echo "Python utilities must support building wheels (bdist_wheel)"
+          eval "$postBuild"
+        '';
+
+        installPhase = ''
+          mkdir -p $out
+          cp dist/*.whl $out/
+        '';
+
+        # setup hook that creates a "link" file in the
+        # derivation that depends on this wheel derivation
+        setupHook = ./wheelHook.sh;
+      });
+
+      packageWithWheel = package.overrideAttrs (oldAttrs: {
+        buildInputs = oldAttrs.buildInputs ++ [ wheel ];
+      });
     in
     base.mkComponent {
       package = packageWithWheel;

--- a/languages/python/wheelHook.sh
+++ b/languages/python/wheelHook.sh
@@ -1,0 +1,25 @@
+fixupOutputHooks+=('setWheelLink')
+
+setWheelLink() {
+  shopt -s nullglob
+  mkdir -p $out/nedryland
+
+  # first, get all wheels for this derivation
+  wheels=(@out@/*.whl)
+  if [ ! ${#wheels[@]} -eq 0 ]; then
+    echo -n "${wheels[@]}" > $out/nedryland/wheels
+  fi
+
+  # then, get all wheels for dependencies
+  # note that this file will contain all transitive dependencies
+  # and is therefore naturally "recursive"
+  for pi in $propagatedBuildInputs; do
+    if [ -f $pi/nedryland/wheels ]; then
+      echo -n " " >> $out/nedryland/wheels
+      cat $pi/nedryland/wheels >> $out/nedryland/wheels
+    fi
+  done
+
+  echo "" >> $out/nedryland/wheels
+  shopt -u nullglob
+}


### PR DESCRIPTION
The wheel is built as a separate derivation and uses a setup hook to
insert a "link file" into the original derivation. This keeps the
dependency proper and does not introduce "eval-time dependencies"