### PR TITLE
✨ [PIPE-1002] Make src paths invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Make src path invariant for Python and Rust packages. This makes it cacheable for everyone, irrespective of
+  their path to the repositories. See
+  [this](https://nix.dev/anti-patterns/language.html#reproducability-referencing-top-level-directory-with)
+  for more details.
 - Rust packages no longer output duplicate dependencies 🍄.
 - Update rust-analyzer to 2020-08-03.
 

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -58,8 +58,9 @@ let
   );
 in
 pythonPkgs.buildPythonPackage ({
-  inherit version src setupCfg pylintrc format preBuild;
+  inherit version setupCfg pylintrc format preBuild;
   pname = name;
+  src = builtins.path { path = src; inherit name; };
 
   # Dependencies needed for running the checkPhase. These are added to nativeBuildInputs when doCheck = true. Items listed in tests_require go here.
   checkInputs = with pythonPkgs; [


### PR DESCRIPTION
This will make cross-machine caching of build results possible. More
details can be found
[here](https://nix.dev/anti-patterns/language.html#reproducability-referencing-top-level-directory-with).