### PR TITLE
✨ [PIPE-999] Expose shellInputs and shellHook for rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Rust functions can now pass in shellInputs and shellHooks.
 - Make src path invariant for Python and Rust packages. This makes it cacheable for everyone, irrespective of
   their path to the repositories. See
   [this](https://nix.dev/anti-patterns/language.html#reproducability-referencing-top-level-directory-with)

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -10,6 +10,8 @@ pkgs: base: { name
             , extraChecks ? ""
             , buildFeatures ? [ ]
             , testFeatures ? [ ]
+            , shellInputs ? [ ]
+            , shellHook ? ""
             }:
 let
   rustPhase = ''
@@ -207,7 +209,8 @@ pkgs.stdenv.mkDerivation (
       rust
     ] ++ buildInputs ++ (pkgs.lib.lists.optionals (defaultTarget == "wasm32-wasi") [ pkgs.wasmer ]);
 
-    shellInputs = [ rustAnalyzer ];
+    shellInputs = shellInputs ++ [ rustAnalyzer ];
+
     configurePhase = ''
       mkdir -p nix-deps
 
@@ -239,6 +242,7 @@ pkgs.stdenv.mkDerivation (
     shellHook = ''
       eval "$configurePhase"
       ${cargoAlias}
+      ${shellHook}
     '';
 
     # always want backtraces when building or in dev


### PR DESCRIPTION
Rust packages can now add inputs and commands to run for the shell.