### PR TITLE
⚡️ Stop using a binary plan for Terraform

### DIFF
--- a/deployment/terraform.nix
+++ b/deployment/terraform.nix
@@ -12,7 +12,7 @@ pkgs:
 
     installPhase = ''
       mkdir -p $out
-      terraform apply ${package}/plan
+      terraform apply -auto-approve
 
       terraform output -json > $out/output.json
     '';

--- a/languages/terraform/default.nix
+++ b/languages/terraform/default.nix
@@ -22,7 +22,7 @@
         '';
 
         buildPhase = ''
-          terraform plan -out=plan
+          terraform plan -no-color > plan
         '';
 
         installPhase = ''


### PR DESCRIPTION
- There are security risks with storing the plan since it contains
unencrypted secrets:
https://www.terraform.io/docs/commands/plan.html#security-warning
- It is binary so we cannot use it for display purposes