### PR TITLE
🔨 🐛 Remove use of TF_CLI_ARGS

### DIFF
--- a/languages/terraform/default.nix
+++ b/languages/terraform/default.nix
@@ -48,7 +48,17 @@
 
         shellHook = ''
           cp "$variablesFilePath" /tmp/tfvars.json
-          export TF_CLI_ARGS="-var-file=/tmp/tfvars.json"
+
+          terraform_with_args()
+          {
+            subcommand="$1"
+            if [ "$subcommand" == "apply" ] || [ "$subcommand" == "plan" ]; then
+               command terraform "$@" -var-file=/tmp/tfvars.json
+            else
+               command terraform "$@"
+            fi
+          }
+
           terraform()
           {
             ${preTerraformHook}
@@ -57,10 +67,10 @@
             if [ $# -gt 0 ] && [ "$subcommand" == "apply" ]; then
               echo "Local 'apply' has been disabled, which probably means that application of Terraform config is done centrally"
             else
-              command terraform "$@"
+              terraform_with_args "$@"
             fi
           '' else ''
-            command terraform "$@"
+            terraform_with_args "$@"
           ''}
             ${postTerraformHook}
           }


### PR DESCRIPTION
- We added TF_CLI_ARGS before which made sure it added certain
arguments to all terraform commands. Added a variable called -var-file
which inputs vars to terraform through this environment
variable. Turns out all terraform commands do not support it which
makes TF_CLI_ARGS useless to us. Created and alias to apply the
-var-file argument when applicable instead.