### PR TITLE
🐛 Need the same buildInputs for deploying TF

### DIFF
--- a/deployment/terraform.nix
+++ b/deployment/terraform.nix
@@ -2,7 +2,7 @@ pkgs:
 {
   terraformComponent = attrs@{ package, ... }: pkgs.stdenv.mkDerivation (attrs // {
     name = "terraform-deploy-${package.name}";
-    buildInputs = [ package pkgs.terraform_0_13 ];
+    buildInputs = [ package pkgs.terraform_0_13 package.buildInputs ];
 
     src = package.src;
 
@@ -12,6 +12,7 @@ pkgs:
 
     installPhase = ''
       mkdir -p $out
+      export HOME="$PWD"
       terraform apply -var-file="${package}/vars.json" -auto-approve
 
       terraform output -json > $out/output.json


### PR DESCRIPTION
The Terraform deployment derivation now inherits the buildInputs from
the package we are deploying.