### PR TITLE
🐛 Add state lock timeout to terraform deploy

### DIFF
--- a/deployment/terraform.nix
+++ b/deployment/terraform.nix
@@ -7,13 +7,13 @@ pkgs:
     src = package.src;
 
     configurePhase = ''
-      terraform init
+      terraform init -lock-timeout=300s
     '';
 
     installPhase = ''
       mkdir -p $out
       export HOME="$PWD"
-      terraform apply -var-file="${package}/vars.json" -auto-approve
+      terraform apply -var-file="${package}/vars.json" -auto-approve -lock-timeout=300s
 
       terraform output -json > $out/output.json
     '';


### PR DESCRIPTION
Forgot this when we added it to the normal Terraform derivation.