### PR TITLE
⚡️ Support arbitrary attributes for Rust packages

### DIFF
--- a/languages/rust/default.nix
+++ b/languages/rust/default.nix
@@ -16,6 +16,7 @@ rec {
     , extraChecks ? ""
     , buildFeatures ? [ ]
     , testFeatures ? [ ]
+    , ...
     }:
     let
       package = mkPackage {
@@ -61,11 +62,12 @@ rec {
     , extraChecks ? ""
     , buildFeatures ? [ ]
     , testFeatures ? [ ]
+    , ...
     }:
     let
-      package = mkPackage {
+      package = mkPackage (attrs // {
         inherit name src buildInputs rustDependencies extensions targets useNightly extraChecks buildFeatures testFeatures;
-      };
+      });
 
       newPackage = package.overrideAttrs (
         oldAttrs: {
@@ -92,11 +94,12 @@ rec {
     , extraChecks ? ""
     , buildFeatures ? [ ]
     , testFeatures ? [ ]
+    , ...
     }:
     let
-      package = mkPackage {
+      package = mkPackage (attrs // {
         inherit name src buildInputs rustDependencies extensions targets useNightly extraChecks buildFeatures testFeatures;
-      };
+      });
 
       newPackage = package.overrideAttrs (
         oldAttrs: {

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -1,4 +1,4 @@
-pkgs: base: { name
+pkgs: base: attrs@{ name
             , src
             , buildInputs ? [ ]
             , extensions ? [ ]
@@ -12,6 +12,7 @@ pkgs: base: { name
             , testFeatures ? [ ]
             , shellInputs ? [ ]
             , shellHook ? ""
+            , ...
             }:
 let
   rustPhase = ''
@@ -100,9 +101,11 @@ let
     fi
     }
   '';
+
+  safeAttrs = builtins.removeAttrs attrs [ "rustDependencies" "extraChecks" "testFeatures" "buildFeatures" ];
 in
 pkgs.stdenv.mkDerivation (
-  {
+  safeAttrs // {
     inherit name;
     src =
       (builtins.path {
@@ -119,7 +122,7 @@ pkgs.stdenv.mkDerivation (
     nativeBuildInputs = with pkgs; [
       cacert
       rust
-    ] ++ buildInputs ++ (pkgs.lib.lists.optionals (defaultTarget == "wasm32-wasi") [ pkgs.wasmer-with-run ]);
+    ] ++ attrs.nativeBuildInputs or [ ] ++ buildInputs ++ (pkgs.lib.lists.optionals (defaultTarget == "wasm32-wasi") [ pkgs.wasmer-with-run ]);
 
     shellInputs = shellInputs ++ [ pkgs.rust-analyzer ];
 


### PR DESCRIPTION
Adding named attributes each time we want to do something that is
actually supported on the underlying derivation is just annoying.