### PR TITLE
🔥 Remove RUST_BACKTRACE because it was too verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- RUST_BACKTRACE was enabled by default. Removed it. Enable it manually when needed instead.
+
 ### Changed
 - Use niv for handling nix dependencies.
 

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -154,7 +154,6 @@ pkgs.stdenv.mkDerivation (
     '';
 
     shellHook = ''
-      export RUST_BACKTRACE=1
       eval "$configurePhase"
       ${cargoAlias}
       ${shellHook}


### PR DESCRIPTION
Better to enable it manually when you need it.