### PR TITLE
⚡️ Proper overlay for python packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use niv for handling nix dependencies.
+- Python overlays now work for both Python 3.7 and 3.8. Furthermore it is exposed both on the
+  interpreter package and as <python-version>Packages.
 
 ### Added
 - Support arbitrary attribute for python packages and make checkInputs, buildInputs, propagatedBuildinputs optional.

--- a/overlays/python_packages.nix
+++ b/overlays/python_packages.nix
@@ -1,92 +1,130 @@
 self: super:
-{
-  python3Packages = rec {
-    grpcio-testing = super.python3Packages.buildPythonPackage rec {
-      pname = "grpcio-testing";
-      version = "1.26.0";
+let
+  pythonVersions = [
+    {
+      pkg = super.python38;
+      attr = "python38";
+    }
+    {
+      pkg = super.python37;
+      attr = "python37";
+    }
+  ];
+in
+(builtins.foldl'
+  (combined: pythonVersion:
+    (combined // rec {
+      # pkgs.<python-version>.pkgs
+      "${pythonVersion.attr}" = pythonVersion.pkg.override {
+        packageOverrides = self: super: rec {
 
-      src = super.python3Packages.fetchPypi {
-        inherit pname version;
-        sha256 = "0svwdw824z8d49l8100qibkjgl84bpdg3jyccfidzx351nj2wal8";
+          grpcio-testing = super.buildPythonPackage rec {
+            pname = "grpcio-testing";
+            version = "1.26.0";
+
+            src = super.fetchPypi {
+              inherit pname version;
+              sha256 = "0svwdw824z8d49l8100qibkjgl84bpdg3jyccfidzx351nj2wal8";
+            };
+
+            preBuild = ''
+              export HOME=$PWD
+            '';
+
+            doCheck = false;
+            propagatedBuildInputs = [
+              super.six
+              super.protobuf
+              super.grpcio
+            ];
+          };
+
+          clique = super.buildPythonPackage rec {
+            pname = "clique";
+            version = "1.5.0";
+
+            preBuild = ''
+              export HOME=$PWD
+            '';
+
+            src = super.fetchPypi {
+              inherit pname version;
+              sha256 = "c34a4eac30187a5b7d75bc8cf600ddc50ceef50a423772a4c96f1dc8440af5fa";
+            };
+
+            doCheck = false;
+          };
+
+          ftrack-python-api = super.buildPythonPackage rec {
+            pname = "ftrack-python-api";
+            version = "2.0.0rc2";
+
+            preBuild = ''
+              export HOME=$PWD
+            '';
+
+            src = super.fetchPypi {
+              inherit pname version;
+              sha256 = "77e20cd7ab2d9e45edba7dbbb3404e51b9919618f83f44902aab33f1b298fdc9";
+            };
+
+            doCheck = false;
+            propagatedBuildInputs = [
+              clique
+              super.termcolor
+              super.websocket_client
+              super.pyparsing
+              super.future
+              super.requests
+              super.arrow
+              super.six
+            ];
+          };
+
+          cloudevents = super.buildPythonPackage rec {
+            pname = "cloudevents";
+            version = "0.3.0";
+
+            src = super.fetchPypi {
+              inherit pname version;
+              sha256 = "c76e1f4341cbb7e042794bd45551c75c8e069fad30c2e29d682e978e85c7a7fb";
+            };
+
+            preBuild = ''
+              export HOME=$PWD
+            '';
+
+            doCheck = false;
+          };
+
+          functions-framework = super.buildPythonPackage rec {
+            pname = "functions-framework";
+            version = "2.0.0";
+
+            src = super.fetchPypi {
+              inherit pname version;
+              sha256 = "641bc800e480f7eec3759ca6a972753cd8bdca48aec591cdbfc65bc955f3074c";
+            };
+
+            preBuild = ''
+              export HOME=$PWD
+            '';
+
+            propagatedBuildInputs = [
+              cloudevents
+              super.flask
+              super.gunicorn
+              super.watchdog
+            ];
+          };
+
+        };
       };
 
-      doCheck = false;
-      propagatedBuildInputs = [
-        super.python3Packages.six
-        super.python3Packages.protobuf
-        super.python3Packages.grpcio
-      ];
-    };
-
-    clique = super.python3Packages.buildPythonPackage rec {
-      pname = "clique";
-      version = "1.5.0";
-
-      preBuild = ''
-        export HOME=$PWD
-      '';
-
-      src = super.python3Packages.fetchPypi {
-        inherit pname version;
-        sha256 = "c34a4eac30187a5b7d75bc8cf600ddc50ceef50a423772a4c96f1dc8440af5fa";
-      };
-
-      doCheck = false;
-    };
-
-    ftrack-python-api = super.python3Packages.buildPythonPackage rec {
-      pname = "ftrack-python-api";
-      version = "2.0.0rc2";
-
-      preBuild = ''
-        export HOME=$PWD
-      '';
-
-      src = super.python3Packages.fetchPypi {
-        inherit pname version;
-        sha256 = "77e20cd7ab2d9e45edba7dbbb3404e51b9919618f83f44902aab33f1b298fdc9";
-      };
-
-      doCheck = false;
-      propagatedBuildInputs = [
-        clique
-        super.python3Packages.termcolor
-        super.python3Packages.websocket_client
-        super.python3Packages.pyparsing
-        super.python3Packages.future
-        super.python3Packages.requests
-        super.python3Packages.arrow
-        super.python3Packages.six
-      ];
-    };
-
-    cloudevents = super.python3Packages.buildPythonPackage rec {
-      pname = "cloudevents";
-      version = "0.3.0";
-
-      src = super.python3Packages.fetchPypi {
-        inherit pname version;
-        sha256 = "c76e1f4341cbb7e042794bd45551c75c8e069fad30c2e29d682e978e85c7a7fb";
-      };
-
-      doCheck = false;
-    };
-
-    functions-framework = super.python3Packages.buildPythonPackage rec {
-      pname = "functions-framework";
-      version = "2.0.0";
-
-      src = super.python3Packages.fetchPypi {
-        inherit pname version;
-        sha256 = "641bc800e480f7eec3759ca6a972753cd8bdca48aec591cdbfc65bc955f3074c";
-      };
-
-      propagatedBuildInputs = [
-        cloudevents
-        super.python3Packages.flask
-        super.python3Packages.gunicorn
-        super.python3Packages.watchdog
-      ];
-    };
-  } // super.python3Packages;
-}
+      # pkgs.<python-version>Packages
+      "${pythonVersion.attr}Packages" = pythonVersion.pkg.pkgs;
+    })
+  )
+  { }
+  pythonVersions
+)


### PR DESCRIPTION
Fixes #87

Now we instead map a set of packages over both python 3.7 and 3.8. It is
also exposed both as <interpreter>.pkgs and <python-version>Packages.