### PR TITLE
⚡️ Do not add all the source to rust utilities

### DIFF
--- a/languages/rust/default.nix
+++ b/languages/rust/default.nix
@@ -30,7 +30,7 @@ rec {
             ${oldAttrs.buildPhase}
             ${oldAttrs.checkPhase}
           '';
-          installPhase = ''
+          installPhase = attrs.installPhase or ''
             ${oldAttrs.installPhase}
             mkdir -p $out
 


### PR DESCRIPTION
If `installPhase` is overridden, simply use that and do not add extra
stuff.