### PR TITLE
✨ Set warnings as errors by default for Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use niv for handling nix dependencies.
 - Python overlays now work for both Python 3.7 and 3.8. Furthermore it is exposed both on the
   interpreter package and as <python-version>Packages.
+- Set warnings as errors by default on all Rust projects. This can be turned off with the argument
+  `warningsAsErrors` on all rust nix helpers (`mkService`, `mkClient` etc.).
 
 ### Added
 - Support arbitrary attribute for python packages and make checkInputs, buildInputs, propagatedBuildinputs optional.

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -12,6 +12,7 @@ pkgs: base: attrs@{ name
             , testFeatures ? [ ]
             , shellInputs ? [ ]
             , shellHook ? ""
+            , warningsAsErrors ? true
             , ...
             }:
 let
@@ -191,6 +192,10 @@ pkgs.stdenv.mkDerivation (
           exit $exit_code
         '';
       };
+    } else { }
+  ) // (
+    if warningsAsErrors then {
+      RUSTFLAGS = "-D warnings";
     } else { }
   )
 )


### PR DESCRIPTION
This can be turned off with the argument `warningsAsErrors` on all rust
nix helpers (`mkService`, `mkClient` etc.).