### PR TITLE
🐛 Ensure we only get mypy paths for our own packages

### DIFF
--- a/languages/python/mypy-hook.sh
+++ b/languages/python/mypy-hook.sh
@@ -1,6 +1,6 @@
 addToMypyPath() {
-    # MYPY does not want python's own site-packages to be in the mypy path
-    if [ $1 != @interpreterPath@ ]; then
+    # We only want mypy dependencies that we've created ourselves to be in the path.
+    if [ -f "$1/nedryland/add-to-mypy-path" ]; then
         addToSearchPathWithCustomDelimiter : MYPYPATH $1/@sitePackages@
     fi
 }

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -69,7 +69,6 @@ let
       name = "mypy-hook";
       substitutions = {
         "sitePackages" = pythonVersion.sitePackages;
-        "interpreterPath" = "${pythonVersion}";
       };
     }
     ./mypy-hook.sh;
@@ -139,5 +138,11 @@ pythonPkgs.buildPythonPackage (attrs // {
        ln -s $pylintrc .pylintrc
     fi
     ${commands}
+  '';
+
+  postFixup = ''
+    ${attrs.postFixup or ""}
+    mkdir -p $out/nedryland
+    touch $out/nedryland/add-to-mypy-path
   '';
 } // standardTests)


### PR DESCRIPTION
Just include the packages we generate ourselves.