### PR TITLE
🔥 Remove vendoring of external dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples of transitive protobuf modules.
 - Language helper for generating protobuf modules.
 - DeclareComponent supports returning attribute sets.
-- Support for vendoring internal and external rust dependencies.
+- Support for vendoring internal rust dependencies.
 - Marker for Nedryland components, isNedrylandComponent = true.
 - Automatically set MYPYPATH from propagatedBuildInputs in python packages.
 - Support arbitrary attribute for python packages and make checkInputs, buildInputs, propagatedBuildInputs optional.

--- a/languages/rust/cargo-external.config.toml
+++ b/languages/rust/cargo-external.config.toml
@@ -1,5 +1,0 @@
-[source.crates-io]
-replace-with = "vendored-crates-io"
-
-[source.vendored-crates-io]
-directory = "@vendorDir@"

--- a/languages/rust/default.nix
+++ b/languages/rust/default.nix
@@ -19,7 +19,7 @@ rec {
     }:
     let
       package = mkPackage (attrs // {
-        vendorDependencies = false;
+        filterCargoLock = true;
       });
 
       checksumHook = pkgs.makeSetupHook

--- a/languages/rust/protobuf/compiler/default.nix
+++ b/languages/rust/protobuf/compiler/default.nix
@@ -3,5 +3,4 @@ mkClient {
   name = "rust-protobuf-compiler";
   src = ./.;
   PROTOC = "${protobuf}/bin/protoc";
-  externalDependenciesHash = "sha256-HYFVW8Du8SKmfSFlMfk/bsLSkEE7bCRpvmyM53L5zLA=";
 }

--- a/languages/rust/vendor.nix
+++ b/languages/rust/vendor.nix
@@ -1,195 +1,47 @@
-pkgs: rust: { src, vendorDependencies, cargoLockHash, externalDependenciesHash, name, buildInputs, propagatedBuildInputs }:
+pkgs: rust: { name, buildInputs, propagatedBuildInputs }:
 let
   internalSetupHook = pkgs.makeSetupHook
     {
       name = "internal-deps-hook";
     }
     ./internalDepsSetupHook.sh;
-
-  # derivation that creates a fake vendor dir
-  # with our internal nix dependencies
-  internal = pkgs.stdenv.mkDerivation {
-    name = "${name}-internal-deps";
-    inherit buildInputs propagatedBuildInputs;
-
-    phases = [ "buildPhase" "installPhase" ];
-    nativeBuildInputs = with pkgs; [ git cacert rust internalSetupHook ];
-
-    buildPhase = ''
-      if [ -n "''${rustDependencies}" ]; then
-        echo "🏡 vendoring internal dependencies..."
-
-        mkdir -p vendored
-
-        # symlink in all deps
-        for dep in $rustDependencies; do
-          ln -sf "$dep" ./vendored/
-        done
-
-        echo "🏡 internal dependencies vendored!"
-      fi
-    '';
-
-    installPhase = ''
-      mkdir $out
-
-      if [ -d vendored ]; then
-        cp -r vendored $out
-      fi
-    '';
-  };
-
-  # a derivation that checks that Cargo.lock is up to date
-  # and generates an up-to-date one if it is not
-  upToDateCargoLock = pkgs.stdenv.mkDerivation {
-    name = "${name}-Cargo.lock";
-    inherit src internal;
-
-    outputHash = cargoLockHash;
-    outputHashAlgo = "sha256";
-
-    phases = [ "unpackPhase" "buildPhase" "installPhase" ];
-
-    nativeBuildInputs = with pkgs; [ git cacert rust ];
-
-    preBuild = ''
-      if [ -d $internal/vendored ]; then
-         substitute ${./cargo-internal.config.toml} config.toml \
-         --subst-var-by vendorDir $internal/vendored
-      fi
-    '';
-
-    buildPhase = ''
-      runHook preBuild
-      export CARGO_HOME=$PWD
-
-      # this will contact crates.io to
-      # check if the lock file is up to date
-      # w.r.t. what is specified in the manifest (Cargo.toml)
-      # We also run all commands with -q because the output
-      # from a successful run is not all that helpful and
-      # error output will still be printed
-      echo "🔐 🧐 Checking if Cargo.lock is up to date..."
-      if cargo update -q --locked; then
-        echo "🔏 👍 Cargo.lock is up to date"
-      else
-        echo -e "🔓 🗓 \e[31mERROR: Cargo.lock is out of date, generating a new one...\e[0m"
-        cargo update -q
-        echo "An up-to-date Cargo.lock for \"${name}\" has been generated at $out"
-
-        echo "Please replace your old lock file with the following command."
-        echo "\"cp $out <path to ${name}/Cargo.lock>\""
-      fi
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      cp Cargo.lock $out
-    '';
-
-    impureEnvVars = pkgs.stdenv.lib.fetchers.proxyImpureEnvVars;
-  };
-
-  # a derivation that generates a "vendor" dir with
-  # all internal and crates.io dependencies
-  external = pkgs.stdenv.mkDerivation {
-    name = "${name}-external-deps";
-    inherit src upToDateCargoLock internal;
-
-    outputHash = externalDependenciesHash;
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-
-    phases = [ "unpackPhase" "buildPhase" "installPhase" ];
-
-    nativeBuildInputs = with pkgs; [ git cacert rust nix coreutils ];
-
-    preBuild = ''
-      if [ -d $internal/vendored ]; then
-         substitute ${./cargo-internal.config.toml} config.toml \
-         --subst-var-by vendorDir $internal/vendored
-      fi
-    '';
-
-    buildPhase = ''
-      runHook preBuild
-
-      export CARGO_HOME=$PWD
-
-      cp Cargo.lock Cargo.lock.orig
-
-      # We need to set this so that
-      # cargo vendor will generate timestamps
-      # that corresponds to those that will be in the
-      # nix store (unix epoch 1). Otherwise the generated
-      # checksums will change and cargo will not be able
-      # to use the vendored packages
-      export SOURCE_DATE_EPOCH=1
-
-      echo "🌍 vendoring dependencies from crates.io..."
-      cargo vendor -q --versioned-dirs --locked --respect-source-config vendored
-      echo "🌍 dependencies from crates.io vendored!"
-
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      mkdir $out
-
-      if [ "$(ls -A vendored)" ]; then
-        cp -r vendored $out
-      fi
-
-      newSha256=$(nix hash-path $out --type sha256)
-      oldSha256=$(nix to-base64 $outputHash --type sha256)
-      formattedNewSha256=$(nix to-base64 $newSha256 --type sha256)
-      if [ "$formattedNewSha256" != "$oldSha256" ]; then
-         echo -e "❌🔮 \e[31mHash mismatch for external dependencies!\e[0m"
-         echo -e "     \e[1mProvided Hash:\e[0m \"$oldSha256\""
-         echo -e "     \e[1mExternal Dependencies Hash:\e[0m \"$formattedNewSha256\""
-         echo -e "     \e[1mMake sure you are providing the correct hash for \"${name}\":\e[0m externalDependenciesHash = \"$newSha256\";"
-
-         if ! cmp -s Cargo.lock Cargo.lock.orig; then
-           echo "     This might be since there is a mismatch in Cargo.lock (i.e. vendoring created a new lock file)"
-         else
-           echo "     However, the cargo lock files are identical!"
-         fi
-
-         exit 1
-      fi
-    '';
-    impureEnvVars = pkgs.stdenv.lib.fetchers.proxyImpureEnvVars;
-  };
-
 in
-pkgs.stdenv.mkDerivation ({
-  name = "${name}-vendored-dependencies";
-  inherit internal;
+# derivation that creates a fake vendor dir
+  # with our internal nix dependencies
+pkgs.stdenv.mkDerivation {
+  name = "${name}-internal-deps";
+  inherit buildInputs propagatedBuildInputs;
+
   phases = [ "buildPhase" "installPhase" ];
+  nativeBuildInputs = with pkgs; [ git cacert rust internalSetupHook ];
 
   buildPhase = ''
-    if [ -d $internal/vendored ]; then
-       substitute ${./cargo-internal.config.toml} internal-cargo.config.toml \
-       --subst-var-by vendorDir $internal/vendored
+    if [ -n "''${rustDependencies}" ]; then
+      echo "🏡 vendoring internal dependencies..."
 
-       cat internal-cargo.config.toml >> cargo.config.toml
-    fi
+      mkdir -p vendored
 
-    if [ -n "''${external-}" ] && [ -d $external/vendored ]; then
-       substitute ${./cargo-external.config.toml} external-cargo.config.toml \
-       --subst-var-by vendorDir $external/vendored
+      # symlink in all deps
+      for dep in $rustDependencies; do
+        ln -sf "$dep" ./vendored/
+      done
 
-       cat external-cargo.config.toml >> cargo.config.toml
+      echo "🏡 internal dependencies vendored!"
     fi
   '';
 
   installPhase = ''
-    mkdir -p $out
-    if [ -f cargo.config.toml ]; then
-       cp cargo.config.toml $out
-       mkdir -p "$out/nix-support"
-       substituteAll "$setupHook" "$out/nix-support/setup-hook"
+    mkdir $out
+
+    if [ -d vendored ]; then
+      cp -r vendored $out
+      substitute ${./cargo-internal.config.toml} $out/cargo.config.toml \
+       --subst-var-by vendorDir $out/vendored
+
+      mkdir -p "$out/nix-support"
+      substituteAll "$setupHook" "$out/nix-support/setup-hook"
     fi
   '';
+
   setupHook = ./setupHook.sh;
-} // (if vendorDependencies then { inherit external; } else { }))
+}


### PR DESCRIPTION
Internal dependencies are still "vendored" like before.

It adds unneccesary complexity at this point in the project and cargo
vendor, with the requirements it has on the up-to-dateness of
Cargo.lock, makes vendoring inconvenient.

Instead, we should use Cargo.lock as an input to create a series of
fixed output derivations (the hash is in Cargo.lock) followed by a
derivation to create a vendor directory from these. See goodbyekansas/nedryglot#2 