### PR TITLE
🐛 Fix endless recursion when building terraform component

### DIFF
--- a/deployment/terraform.nix
+++ b/deployment/terraform.nix
@@ -1,6 +1,6 @@
 pkgs:
 {
-  terraformComponent = attrs@{ package, ... }: pkgs.stdenv.mkDerivation (attrs // {
+  terraformComponent = attrs@{ package, ... }: pkgs.stdenv.mkDerivation ((builtins.removeAttrs attrs [ "package" ]) // {
     name = "terraform-deploy-${package.name}";
     buildInputs = [ package pkgs.terraform_0_13 package.buildInputs ];
 


### PR DESCRIPTION
Encountered an issue where it would contain the package attribute
which would make the component reference itself. Solved by just
removing the package attribute before merge.