### PR TITLE
🐛 Fix accidental double shell hooks

### DIFF
--- a/languages/rust/default.nix
+++ b/languages/rust/default.nix
@@ -115,6 +115,7 @@ rec {
       );
     in
     base.mkService (attrs // { inherit deployment; package = newPackage; });
+
   fromProtobuf = { name, protoSources, version, includeServices, protoInputs }:
     let
       generatedCode = pkgs.callPackage ./protobuf.nix { inherit name protoSources version mkClient includeServices protoInputs; };

--- a/languages/rust/setupHook.sh
+++ b/languages/rust/setupHook.sh
@@ -13,4 +13,3 @@ createCargoConfig() {
 
 preConfigureHooks+=(createCargoConfig)
 preShellHooks+=(createCargoConfig)
-

--- a/shell.nix
+++ b/shell.nix
@@ -21,10 +21,16 @@ pkgs.lib.mapAttrsRecursiveCond
         let
           pkg = component.packageWithChecks;
           name = component.name or (builtins.concatStringsSep "." attrName);
-          shellPkg = pkg.drvAttrs // {
+          shellPkg = pkg.drvAttrs // rec {
             name = "${pkg.name}-shell";
+
+            hook = pkg.shellHook or "";
             nativeBuildInputs = (pkg.shellInputs or [ ]);
-            inputsFrom = [ pkg ];
+
+            # we will get double shellhooks if we do not
+            # remove this here
+            inputsFrom = [ (builtins.removeAttrs pkg [ "shellHook" ]) ];
+
             componentDir = builtins.toString component.path;
             shellHook = ''
               componentDir="$componentDir"
@@ -35,7 +41,7 @@ pkgs.lib.mapAttrsRecursiveCond
               echo ⛑ Changing dir to \"$componentDir\"
               cd "$componentDir"
               echo 🐚 Running shell hook for \"${name}\"
-              ${pkg.shellHook or ""}
+              ${hook}
               echo 🥂 You are now in a shell for working on \"${name}\"
             '';
           };


### PR DESCRIPTION
`inputsFrom` also adds to the shell hook, something we do not want.