### PR TITLE
🐛 Fix bug where terraform failures were ignored

### DIFF
--- a/deployment/terraform/terraform.py
+++ b/deployment/terraform/terraform.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import typing
 
 
@@ -76,6 +77,7 @@ def main() -> None:
             args.func(args)
     except subprocess.CalledProcessError as cpe:
         print(f"Failed to run terraform: {cpe}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We have a python script that handles the terraform apply. This script
caught the error but didn't exit with a non zero exit code.

Made it exit with exit code 1 if anything fails.