### PR TITLE
⚡ Make the error when using $out in deploy clearer

### DIFF
--- a/deployment.nix
+++ b/deployment.nix
@@ -24,7 +24,7 @@ let
           '')
           # These variables are needed for stdenvs setup
           ''
-            declare -x out="/not-set"
+            declare -x out="/deploy/should/not/generate/output"
             declare -x SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
             declare -x noDumpEnvVars=1
           ''


### PR DESCRIPTION
Deployment should never create output