### PR TITLE
🐛 Send linker flavor to rust when cross compiling

### DIFF
--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -206,8 +206,13 @@ stdenv.mkDerivation (
       );
     } else { }
   ) // (
-    if warningsAsErrors then {
-      RUSTFLAGS = ''${if attrs ? RUSTFLAGS then "${attrs.RUSTFLAGS} " else ""}-D warnings'';
+    let
+      flagList = pkgs.lib.optional (attrs ? RUSTFLAGS) attrs.RUSTFLAGS
+      ++ pkgs.lib.optional warningsAsErrors "-D warnings"
+      ++ pkgs.lib.optional (hostTriple == "wasm32_wasi") "-Clinker-flavor=gcc";
+    in
+    if flagList != [ ] then {
+      RUSTFLAGS = builtins.concatStringsSep " " flagList;
     } else { }
   ) // (
     if hostTriple != buildTriple then {


### PR DESCRIPTION
When we change the linker for wasi we break rust's auto detection of the
linker flavor and therefore we need to be explicit about which linker
flavor it is.