### PR TITLE
🐛 Exclude srcExclude from attributes in package

### DIFF
--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -1,4 +1,4 @@
-pkgs: base: attrs@{ name
+pkgs: base: attrs_@{ name
             , version
             , src
             , pythonVersion
@@ -83,6 +83,7 @@ let
     }
     ./mypy-hook.sh;
   setupPyTemplate = if setuptoolsLibrary then ./setup-template-library else ./setup-template-application;
+  attrs = builtins.removeAttrs attrs_ [ "srcExclude" ];
 in
 pythonPkgs.buildPythonPackage (attrs // {
   inherit version setupCfg pylintrc format preBuild;


### PR DESCRIPTION
It is just a parameter to the function and not a desired attribute on the
set.

Saving files is hard :(