### PR TITLE
✨ Expose wheel hook and use it on pycue and pyoutline

### DIFF
--- a/languages/python/default.nix
+++ b/languages/python/default.nix
@@ -3,6 +3,10 @@ rec {
 
   mkPackage = import ./package.nix pkgs base;
 
+  # setup hook that creates a "link" file in the
+  # derivation that depends on this wheel derivation
+  wheelHook = pkgs.makeSetupHook { name = "copyWheelHook"; } ./wheelHook.sh;
+
   fromProtobuf = { name, version, protoSources, protoInputs, pythonVersion ? pkgs.python3 }:
     let
       generatedCode = pkgs.callPackage ./protobuf.nix { inherit name version protoSources protoInputs; };
@@ -43,11 +47,8 @@ rec {
         setuptoolsLibrary = true;
       });
 
-      # setup hook that creates a "link" file in the
-      # derivation that depends on this wheel derivation
-      wheel = pkgs.makeSetupHook { name = "copyWheelHook"; } ./wheelHook.sh;
       packageWithWheel = package.overrideAttrs (oldAttrs: {
-        buildInputs = oldAttrs.buildInputs ++ [ wheel ];
+        buildInputs = oldAttrs.buildInputs ++ [ wheelHook ];
       });
     in
     base.mkComponent {

--- a/overlays/python_packages.nix
+++ b/overlays/python_packages.nix
@@ -13,6 +13,8 @@ let
   isDarwin = super.stdenv.isDarwin;
   fetchzip = super.fetchzip;
   tzdata = super.tzdata;
+
+  wheelHook = super.makeSetupHook { name = "copyWheelHook"; } ../languages/python/wheelHook.sh;
 in
 (builtins.foldl'
   (combined: pythonVersion:
@@ -81,6 +83,9 @@ in
               super.grpcio
               super.pyyaml
             ];
+
+            # create a wheel for this since it does not come from pypi
+            buildInputs = [ wheelHook ];
           };
 
           pyoutline = super.buildPythonPackage rec {
@@ -111,6 +116,9 @@ in
               super.six
               pycue
             ];
+
+            # create a wheel for this since it does not come from pypi
+            buildInputs = [ wheelHook ];
           };
 
           grpcio-testing = super.buildPythonPackage rec {


### PR DESCRIPTION
External dependencies that does not come from pip does not generate
wheels. Hook into the nedryland functionality for appending a built
wheel to the derivation output. Note that this only works for
pure-python dependencies ("universal" wheels) at the moment.