### PR TITLE
🐛 Fix shell not getting check inputs

### DIFF
--- a/component.nix
+++ b/component.nix
@@ -1,5 +1,6 @@
 pkgs:
-let
+rec {
+
   enableChecksOnComponent = component:
     builtins.mapAttrs
       (n: v:
@@ -17,8 +18,7 @@ let
             } else { }))
         else v)
       component;
-in
-{
+
   mkComponent =
     enableChecks: path: mkCombinedDeployment: attrs@{ name, ... }:
     let

--- a/default.nix
+++ b/default.nix
@@ -250,6 +250,7 @@ in
         shells = pkgs.callPackage ./shell.nix {
           inherit components;
           mapComponentsRecursive = minimalBase.mapComponentsRecursive;
+          enableChecksOnComponent = componentFns.enableChecksOnComponent;
           parseConfig = minimalBase.parseConfig;
           extraShells = appliedAttrs.extraShells or { };
         };


### PR DESCRIPTION
Now we instead use the same code that enable checks on the matrix to
enable it on the components individually. The reason that the shells
do not just use the matrix variant with checks is that it would cause
all inputs to all shells to run with checks, something that a user
would not expect.