### PR TITLE
🐛 Remap paths in Rust binaries to be deterministic

### DIFF
--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -117,8 +117,9 @@ pythonPkgs.buildPythonPackage (attrs // {
   # Build-time only dependencies. Typically executables as well
   # as the items listed in setup_requires
   nativeBuildInputs = attrs.nativeBuildInputs or (x: [ ]) pythonPkgs
-    ++ [ mypyHook ]
-    ++ (pkgs.lib.lists.optionals pkgs.lib.inNixShell (attrs_.shellInputs or [ ]));
+    ++ [ mypyHook ];
+
+  passthru = { shellInputs = (attrs_.shellInputs or [ ]); };
 
   # Aside from propagating dependencies, buildPythonPackage also injects
   # code into and wraps executables with the paths included in this list.

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -158,8 +158,9 @@ stdenv.mkDerivation
         removeReferencesTo
       ] ++ attrs.nativeBuildInputs or [ ]
       ++ (pkgs.lib.lists.optionals (defaultTarget == "wasm32-wasi") [ pkgs.wasmer-with-run ])
-      ++ [ vendor ]
-      ++ (pkgs.lib.lists.optionals pkgs.lib.inNixShell (attrs.shellInputs or [ ] ++ [ rustSrcNoSymlinks ]));
+      ++ [ vendor ];
+
+      passthru = { shellInputs = (attrs.shellInputs or [ ] ++ [ rustSrcNoSymlinks ]); };
 
       depsBuildBuild = [ buildPackages.stdenv.cc ]
       ++ pkgs.lib.optionals stdenv.buildPlatform.isDarwin [


### PR DESCRIPTION
We had an issue where the same derivation could have different
checksums. This was due to paths in the binaries being
different. Removing the root path solves the issue.