### PR TITLE
🐛 Use correct entry point format in python

### DIFF
--- a/languages/python/component-template/@mainPackage@/main.py
+++ b/languages/python/component-template/@mainPackage@/main.py
@@ -1,2 +1,6 @@
+""" @desc@ """
+
+
 def main() -> None:
+    """ main function of @mainPackage@ """
     raise NotImplementedError

--- a/languages/python/component-template/setup.py
+++ b/languages/python/component-template/setup.py
@@ -9,5 +9,5 @@ setup(
     author_email="@email@",
     description="@desc@",
     packages=find_packages(),
-    entry_points=[@entryPoint@],
+    entry_points=@entryPoint@,
 )

--- a/languages/python/component-template/tests/test_main.py
+++ b/languages/python/component-template/tests/test_main.py
@@ -1,4 +1,6 @@
-import @mainPackage@
+""" Tests for @mainPackage@ in @pname@ """
+import @mainPackage@.main
 
 def test_main() -> None:
-    @mainPackage@.main()
+    """ Tests for the main function """
+    @mainPackage@.main.main()

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -143,11 +143,11 @@ pythonPkgs.buildPythonPackage (attrs // {
         pkgs.lib.optional (attrs_ ? targetSetup.templateDir) attrs_.targetSetup.templateDir
       ) ++ [ ./component-template ];
     };
-    variables = ({
+    variables = (rec {
       inherit version;
       pname = name;
       mainPackage = pkgs.lib.toLower (builtins.replaceStrings [ "-" " " ] [ "_" "_" ] name);
-      entryPoint = if setuptoolsLibrary then "" else "\\\"${name}=${name}.main:main\\\"";
+      entryPoint = if setuptoolsLibrary then "{}" else "{\\\"console_scripts\\\": [\\\"${name}=${mainPackage}.main:main\\\"]}";
     } // attrs_.targetSetup.variables or { });
     variableQueries = ({
       desc = "✍️ Write a short description for your function";
@@ -155,6 +155,7 @@ pythonPkgs.buildPythonPackage (attrs // {
       email = "📧 Enter author email:";
       url = "🏄 Enter author website url:";
     } // attrs_.targetSetup.variableQueries or { });
+    initCommands = "black .";
   };
 
   shellHook = ''


### PR DESCRIPTION
`nix-build` should now work on a new component (low bar). Also `check`
in the shell of a new component a new component will pass everything
except that the main function raises NotImplementedError.
Fixes include:
- entry_points={"console_scripts": ["name=package:function"]}
- add more default doc strings
- run black so long names don't cause too long lines
- use mainPackage when a module name is required and not package name
- import correct module when testing