### PR TITLE
⚡ Pass arguments from `mkCombinedDeployment`

### DIFF
--- a/deployment.nix
+++ b/deployment.nix
@@ -98,7 +98,7 @@ in
             acc: curr: ''
               ${acc}
               echo "📡👽 Deploying ${curr}..."
-              ${builtins.getAttr curr deployments}/bin/deploy 2>&1 | sed "s/^/ 🛸 ''${esc}[36m[${curr}]''${esc}[0m /"
+              ${builtins.getAttr curr deployments}/bin/deploy "$@" 2>&1 | sed "s/^/ 🛸 ''${esc}[36m[${curr}]''${esc}[0m /"
             ''
           )
           ''


### PR DESCRIPTION
Each deploy script will get the same arguments and it's up to them to
deal with that. This way the behavior stays the same if a new deployment
is added to a deployment set of one, turning it from that deplyoment to
a combined deployment.