### PR TITLE
⚡ Expose vendored dependencies on rust drvs

### DIFF
--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -172,6 +172,7 @@ stdenv.mkDerivation
       strictDeps = true;
       disallowedReferences = [ vendor ];
       src = invariantSource;
+      vendoredDependencies = vendor;
 
       nativeBuildInputs = with pkgs; [
         cacert


### PR DESCRIPTION
This is needed to be able to build it without Nix (i.e. natively on
other Linux distributions)