### PR TITLE
⬆️ Update Rust and Rust Analyzer

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "debe516584cdda7de5968110833a9bb20a715b8d",
-        "sha256": "0jpmwvqy5h71k27zwg2cjgp0fivapj27pi1vn59vzvk6cr5qxbg7",
+        "rev": "a61440a069e36d8cfe90ff00a2948da790517e29",
+        "sha256": "1pcr4m31ac1df2i5bh6bsph0alh43ainb1kqjm280j0kyj0nh6f8",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/debe516584cdda7de5968110833a9bb20a715b8d.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/a61440a069e36d8cfe90ff00a2948da790517e29.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/versions.nix
+++ b/versions.nix
@@ -1,7 +1,7 @@
 {
   rust = {
-    stable = "1.52.1";
-    analyzer = "2021-05-30";
+    stable = "1.53.0";
+    analyzer = "2021-06-29";
   };
 
   # tonic version needs to be matched with


### PR DESCRIPTION
Rust is now at 1.53.0
(https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html)

Rust Analyzer is now at 2021-06-28
(https://rust-analyzer.github.io/thisweek/2021/06/28/changelog-83.html)