### PR TITLE
🐎 🐛 Always set target subfolder for rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Rust: Always set a target subdirectory when building, not only for cross compile. This way
+  switching between targets will not trigger an unnecessary rebuild 🥝.
+
 ## [1.1.0] - 2021-08-05
 
 ### Added

--- a/languages/rust/default.nix
+++ b/languages/rust/default.nix
@@ -23,7 +23,7 @@ let
         installPhase = ''
           ${oldAttrs.installPhase}
           mkdir -p $out/bin
-          cp target/${package.defaultTarget or ""}/release/${package.executableName or package.meta.name}${
+          cp target/''${CARGO_BUILD_TARGET:-}/release/${package.executableName or package.meta.name}${
             if pkgs.lib.hasInfix "-windows-" package.defaultTarget or "" then
               ".exe"
             else

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -11,7 +11,7 @@ attrs@{ name
 , srcExclude ? [ ]
 , extensions ? [ ]
 , targets ? [ ]
-, defaultTarget ? ""
+, defaultTarget ? stdenv.hostPlatform.config
 , useNightly ? ""
 , extraChecks ? ""
 , buildFeatures ? [ ]
@@ -272,12 +272,8 @@ stdenv.mkDerivation
         ${shellHook}
         runHook postShell
       '';
-
-    } // (
-      if defaultTarget != "" then {
-        CARGO_BUILD_TARGET = defaultTarget;
-      } else { }
-    ) // runnerAttrs // (
+      CARGO_BUILD_TARGET = defaultTarget;
+    } // runnerAttrs // (
       let
         flagList = pkgs.lib.optional (attrs ? RUSTFLAGS) attrs.RUSTFLAGS
         ++ pkgs.lib.optional warningsAsErrors "-D warnings"


### PR DESCRIPTION
For some reason rust wants to rebuild when switching between targets if
one target is built in target and one is built in target/something.