### PR TITLE
⚡ Add networkx to build with trimesh

### DIFF
--- a/overlays/python_packages.nix
+++ b/overlays/python_packages.nix
@@ -60,6 +60,10 @@ in
             nativeBuildInputs = [
               super.numpy
             ];
+
+            propagatedBuildInputs = [
+              super.networkx
+            ];
           };
 
           pycue = super.buildPythonPackage rec {


### PR DESCRIPTION
- Add networkx as propagated build input to trimesh pypkg in order to be able to use graph-algorithms.