### PR TITLE
👕 Set isort profile to black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Set isort profile to black to avoid conflicting linting between isort and black.
+
 ### Removed
 
 - Ability to download a Windows VM for running Rust code on. The usefulness of the feature

--- a/languages/python/setup.cfg
+++ b/languages/python/setup.cfg
@@ -20,3 +20,6 @@ ignore_missing_imports = True
 [mypy-setuptools]
 ignore_missing_imports = True
 
+[isort]
+profile = black
+


### PR DESCRIPTION
Set isort to follow black style to avoid getting conflicts
in linting between the two when running checks.