### PR TITLE
💥 ⚡ Change when and where we build wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - python package keyrings-google-artifactregistry-auth which is
   "keyrings.google-artifactregistry-auth" on pypi.
+- python clients now also build wheels.
+- mypy ignore_missing_imports is now set globally.
 
 ### Fixed
 - Set isort profile to black to avoid conflicting linting between isort and black.
@@ -19,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   did simply not warrant the complexity. Instead, you can set
   `NEDRYLAND_WINDOWS_HOST` to a machine where you have passwordless SSH access and
   cargo will use that machine for `run/test`.
+
+### Changed
+- Python wheels will now be build to $out/nedryland instead of just $out.
 
 ## [2.2.0] - 2021-11-01
 

--- a/languages/python/default.nix
+++ b/languages/python/default.nix
@@ -1,6 +1,6 @@
 { base, pkgs }:
 rec {
-  mkPackage = import ./package.nix pkgs base;
+  mkPackage = import ./package.nix pkgs base wheelHook;
 
   mkDocs = import ./docs.nix base pkgs.lib;
 
@@ -48,15 +48,10 @@ rec {
           doStandardTests;
         setuptoolsLibrary = true;
       });
-
-      packageWithWheel = package.overrideAttrs (oldAttrs: {
-        buildInputs = oldAttrs.buildInputs ++ [ wheelHook ];
-      });
     in
     base.mkLibrary {
-      inherit name;
-      package = packageWithWheel;
-      python = packageWithWheel;
+      inherit name package;
+      python = package;
       docs = mkDocs attrs;
     };
 

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -1,14 +1,14 @@
-pkgs: base: attrs_@{ name
-            , version
-            , src
-            , pythonVersion
-            , srcExclude ? [ ]
-            , preBuild ? ""
-            , format ? "setuptools"
-            , setuptoolsLibrary ? false
-            , doStandardTests ? true
-            , ...
-            }:
+pkgs: base: wheelHook: attrs_@{ name
+                       , version
+                       , src
+                       , pythonVersion
+                       , srcExclude ? [ ]
+                       , preBuild ? ""
+                       , format ? "setuptools"
+                       , setuptoolsLibrary ? false
+                       , doStandardTests ? true
+                       , ...
+                       }:
 let
   pythonPkgs = pythonVersion.pkgs;
   customerFilter = src:
@@ -121,7 +121,7 @@ pythonPkgs.buildPythonPackage (attrs // {
 
   # Build and/or run-time dependencies that need to be be compiled
   # for the host machine. Typically non-Python libraries which are being linked.
-  buildInputs = attrs.buildInputs or (_: [ ]) pythonPkgs;
+  buildInputs = attrs.buildInputs or (_: [ ]) pythonPkgs ++ pkgs.lib.optional (format == "setuptools") wheelHook;
 
   # Build-time only dependencies. Typically executables as well
   # as the items listed in setup_requires

--- a/languages/python/setup.cfg
+++ b/languages/python/setup.cfg
@@ -10,14 +10,6 @@ addopts = -p no:warnings
 [mypy]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
-
-[mypy-grpc]
-ignore_missing_imports = True
-
-[mypy-pytest]
-ignore_missing_imports = True
-
-[mypy-setuptools]
 ignore_missing_imports = True
 
 [isort]

--- a/languages/python/wheelHook.bash
+++ b/languages/python/wheelHook.bash
@@ -6,10 +6,10 @@ setWheelLink() {
   shopt -s nullglob
   mkdir -p "${out:-}"/nedryland
 
-  cp dist/*.whl "$out"/
+  cp dist/*.whl "$out"/nedryland
 
   # first, get all wheels for this derivation
-  wheels=("$out"/*.whl)
+  wheels=("$out"/nedryland/*.whl)
   if [ ! ${#wheels[@]} -eq 0 ]; then
     echo -n "${wheels[@]}" >"$out"/nedryland/wheels
   fi


### PR DESCRIPTION
Build wheels for clients and put them in $out/nedryland. Also turn on
ignore_missing_imports globally for mypy, it created more work than
help.