### PR TITLE
⚡ Set flake8 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Set isort profile to black to avoid conflicting linting between isort and black.
+- Set flake8 configuration to ignore E203 whitespace before ':' to avoid conflicting
+  linting between flake8 and black.
 
 ### Removed
 

--- a/languages/python/setup.cfg
+++ b/languages/python/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 88
+extend-ignore = E203
 
 [pycodestyle]
 max-line-length = 88


### PR DESCRIPTION
Set flake8 configuration to ignore E203 whitespace before ':' to
avoid conflicting linting between flake8 and black.