### PR TITLE
🐛 Fix src filter for base.mkDerivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Src filter for `base.mkDerivation` now correctly excludes additional `srcExclude`s.
+
 ## [3.0.0] - 2021-11-24
 
 ### Added

--- a/default.nix
+++ b/default.nix
@@ -111,8 +111,7 @@ in
                     in
                     filter:
                     path: type:
-                      srcIgnored path type
-                      || (filter path type);
+                      (srcIgnored path type) && (filter path type);
                   filteredSrc =
                     if attrs ? srcFilter && attrs ? src then
                       pkgs.lib.cleanSourceWith


### PR DESCRIPTION
It now takes srcExclude/srcFilter into account properly.