### PR TITLE
🐛 Fix deployPhase bash variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Src filter for python now correctly excludes additional `srcExclude`s.
 - The CI tools shellcheck and nix-lint will no longer check git ignored files.
+- Deploy phases & variables can now use \ characters.
+- Deploy phases can now use nix attributes as environment variables in bash consistently.
 
 ## [3.0.1] - 2021-11-25
 

--- a/deployment.nix
+++ b/deployment.nix
@@ -11,7 +11,7 @@ let
     , ...
     }:
     let
-      env = attrs // {
+      env = builtins.removeAttrs attrs [ "preDeployPhase" "deployPhase" "postDeployPhase" ] // {
         buildInputs = inputs;
       };
       envVars = pkgs.writeTextFile {
@@ -19,7 +19,7 @@ let
         text = builtins.foldl'
           (acc: curr: ''
             ${acc}
-            declare -x ${curr}="${builtins.replaceStrings [ "$" "\"" ] [ "\\$" "\\\"" ] (builtins.toString (builtins.getAttr curr env))}"
+            declare -x ${curr}="${builtins.replaceStrings [ "$" "\"" "\\" ] [ "\\$" "\\\"" "\\\\" ] (builtins.toString (builtins.getAttr curr env))}"
           '')
           # These variables are needed for stdenvs setup
           ''


### PR DESCRIPTION
The phases needs to be declared last so all nix attributes are made into
variables first. Also add \ to list of escaped characters so it can be
used in scripts.