### PR TITLE
🐛 Add the package's nativeBuildinput for rust docs

### DIFF
--- a/languages/rust/default.nix
+++ b/languages/rust/default.nix
@@ -40,7 +40,7 @@ let
           )
           targetNames);
 
-      nativeBuildInputs = with pkgs;[ j2cli jq ];
+      nativeBuildInputs = with pkgs;[ j2cli jq ] ++ attrs.nativeBuildInputs or [ ];
 
       inherit targetNames;
 


### PR DESCRIPTION
Rust wants to build the dependencies before generating the docs, even
with `--no-deps` so we need any nativeBuildinputs that might be
required for that.