### PR TITLE
🐛 Fix defaultTarget not getting buildInputs

### DIFF
--- a/docs/src/languages/rust/components.md
+++ b/docs/src/languages/rust/components.md
@@ -80,11 +80,11 @@ base.languages.rust.mkLibrary rec {
 
   crossTargets = {
     # targetSpec is the supported cross target provided by nedryland.
-    wasi = attrsForTargetSpec: {
+    wasi = {
       # Even if we re-use buildInputs for the windows target it
-      # will pick depencencyA.wasi if it exists(not windows).
+      # will pick depencencyA.wasi if it exists (not windows).
       # If not it will pick dependencyA.package.
-      buildInputs = buildInputs ++ attrsForTargetSpec.buildInputs;
+      inherit buildInputs;
     };
   };
 }

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -168,7 +168,7 @@ in
 base.mkDerivation
   (
     safeAttrs // {
-      inherit stdenv buildInputs propagatedBuildInputs checkInputs;
+      inherit stdenv propagatedBuildInputs checkInputs;
       strictDeps = true;
       disallowedReferences = [ vendor ];
       srcFilter = path: type: !(type == "directory" && baseNameOf path == "target")
@@ -185,6 +185,9 @@ base.mkDerivation
       ]
       ++ runners
       ++ nativeBuildInputs;
+
+      buildInputs = buildInputs
+      ++ (lib.optional stdenv.hostPlatform.isWindows pkgs.pkgsCross.mingwW64.windows.pthreads);
 
       passthru = { shellInputs = (shellInputs ++ [ rustSrcNoSymlinks rustAnalyzer ]); };
 

--- a/test.nix
+++ b/test.nix
@@ -21,8 +21,8 @@ let
     nestedComponents = import ./test/nested-components.nix pkgs tests.hello;
     sameWhenFiltered = import ./test/filter-source.nix pkgs.lib.assertMsg tests.hello.matrix.sameThing1 tests.hello.matrix.sameThing2;
     versionTest = import ./test/dependencies.nix tests.dependencies.matrix.nooo pkgs.lib.assertMsg;
-    rustCross = import ./test/rust-cross.nix pkgs.lib {
-      inherit (pkgs.lib) assertMsg;
+    rustCross = import ./test/rust-cross.nix {
+      inherit (pkgs) lib callPackage stdenv;
       inherit (tests.hello.matrix) baseRust windowsRust crossRust;
     };
     docsTest = import ./test/docs.nix pkgs tests.documentation.matrix;

--- a/test/mock-base.nix
+++ b/test/mock-base.nix
@@ -1,0 +1,11 @@
+rec {
+  mkComponent = attrs:
+    attrs // {
+      overrideAttrs = f: attrs // (f attrs);
+    };
+  mkDerivation = mkComponent;
+
+  mkService = mkComponent;
+  mkClient = mkComponent;
+  mkLibrary = mkComponent;
+}


### PR DESCRIPTION
Now the defaultTarget gets buildInputs from the `buildInputs` in the
enclosing scope. Explicitly defined cross targets do not since we do not
know the correct platform association.