### PR TITLE
🐛 Fix target aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Target aliases on components now maintain that relationship when
+  checks are enabled.
+
+### Changed
+- `base.enableChecks` is not a function that enables checks on a
+  component and `base.checksEnabled` is now a flag that tells if
+  checks are enabled on the matrix.
+
+### Added
+- base.resolveInputs to extract the correct targets from nedryland
+  components when used as derivation inputs.
+
 ## [4.0.0] - 2022-02-14
 
 ### Added

--- a/component.nix
+++ b/component.nix
@@ -1,24 +1,7 @@
 pkgs:
 rec {
-  enableChecksOnComponent =
-    builtins.mapAttrs
-      (_: v:
-        if pkgs.lib.isDerivation v && v ? overrideAttrs then
-          v.overrideAttrs
-            (oldAttrs: {
-              doCheck = true;
-
-              # Python packages don't have a checkPhase, only an installCheckPhase
-              doInstallCheck = true;
-            } // (if v.stdenv.hostPlatform != v.stdenv.buildPlatform && oldAttrs.doCrossCheck or false then {
-              preInstallPhases = [ "crossCheckPhase" ];
-              crossCheckPhase = oldAttrs.checkPhase or "";
-              nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ oldAttrs.checkInputs or [ ];
-            } else { }))
-        else v);
-
   mkComponent =
-    enableChecks: path: mkCombinedDeployment: parseConfig:
+    path: mkCombinedDeployment: parseConfig:
     let
       mkComponentInner = attrs'@{ name, subComponents ? { }, nedrylandType ? "component", ... }:
         let
@@ -52,7 +35,7 @@ rec {
                 };
             }));
 
-          component = if enableChecks then enableChecksOnComponent component' else component';
+          component = component';
           docsRequirement = (parseConfig {
             key = "docs";
             structure = { requirements = { "${component.nedrylandType}" = [ ]; }; };

--- a/languages/python/docs.nix
+++ b/languages/python/docs.nix
@@ -47,7 +47,7 @@ let
         } else { path = docsConfig.logo; }
       ) else { };
 
-  inherit (import ./utils.nix) resolveInputs;
+  inherit (import ./utils.nix base) resolveInputs;
 in
 {
   __functor = self: self."${docsConfig.python.generator}";
@@ -58,8 +58,8 @@ in
     nedrylandType = "documentation";
     buildInputs = [ pythonVersion.pkgs.sphinx4 ]
       ++ lib.optional (sphinxTheme != null) pythonVersion.pkgs."${sphinxTheme.name}"
-      ++ (resolveInputs pythonVersion.pkgs attrs.buildInputs or (_: [ ]))
-      ++ (resolveInputs pythonVersion.pkgs attrs.propagatedBuildInputs or (_: [ ]));
+      ++ (resolveInputs pythonVersion.pkgs name "buildInputs" attrs.buildInputs or (_: [ ]))
+      ++ (resolveInputs pythonVersion.pkgs name "propagatedBuildInputs" attrs.propagatedBuildInputs or (_: [ ]));
 
     srcFilter = path: type: (
       builtins.match ".*\.py" (baseNameOf path) != null
@@ -97,9 +97,9 @@ in
     name = "${name}-api-reference";
     nedrylandType = "documentation";
     buildInputs = [ pythonVersion.pkgs.pdoc ]
-      ++ (resolveInputs pythonVersion.pkgs attrs.buildInputs or (_: [ ]))
-      ++ (resolveInputs pythonVersion.pkgs attrs.propagatedBuildInputs or (_: [ ]));
-    nativeBuildInputs = resolveInputs pythonVersion.pkgs attrs.nativeBuildInputs or (_: [ ]);
+      ++ (resolveInputs pythonVersion.pkgs name "buildInputs" attrs.buildInputs or (_: [ ]))
+      ++ (resolveInputs pythonVersion.pkgs name "propagatedBuildInputs" attrs.propagatedBuildInputs or (_: [ ]));
+    nativeBuildInputs = resolveInputs pythonVersion.pkgs name "nativeBuildInputs" attrs.nativeBuildInputs or (_: [ ]);
     configurePhase = ''
       modules=$(python ${./print-module-names.py})
       ${if logo != { } then "cp -r ${./pdoc-template} ./template" else ""}

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -12,7 +12,7 @@ args@{ name
 }:
 let
   pythonPkgs = pythonVersion.pkgs;
-  resolveInputs = (import ./utils.nix).resolveInputs pythonPkgs;
+  resolveInputs = (import ./utils.nix base).resolveInputs pythonPkgs name;
 
   customerFilter = src:
     let
@@ -74,7 +74,7 @@ let
 
   attrs = builtins.removeAttrs args [ "srcExclude" "shellInputs" "targetSetup" "docs" ];
 in
-pythonPkgs.buildPythonPackage (attrs // {
+base.enableChecks (pythonPkgs.buildPythonPackage (attrs // {
   inherit src version setupCfg pylintrc format preBuild doStandardTests;
   pname = name;
 
@@ -83,22 +83,22 @@ pythonPkgs.buildPythonPackage (attrs // {
     python-language-server
     pyls-mypy
     pyls-isort
-  ] ++ (resolveInputs attrs.checkInputs or (_: [ ]));
+  ] ++ (resolveInputs "checkInputs" attrs.checkInputs or (_: [ ]));
 
   # Build and/or run-time dependencies that need to be be compiled
   # for the host machine. Typically non-Python libraries which are being linked.
-  buildInputs = resolveInputs attrs.buildInputs or (_: [ ]);
+  buildInputs = resolveInputs "buildInputs" attrs.buildInputs or (_: [ ]);
 
   # Build-time only dependencies. Typically executables as well
   # as the items listed in setup_requires
-  nativeBuildInputs = resolveInputs attrs.nativeBuildInputs or (_: [ ]);
+  nativeBuildInputs = resolveInputs "nativeBuildInputs" attrs.nativeBuildInputs or (_: [ ]);
 
-  passthru = { shellInputs = (resolveInputs args.shellInputs or (_: [ ])); };
+  passthru = { shellInputs = (resolveInputs "shellInputs" args.shellInputs or (_: [ ])); };
 
   # Aside from propagating dependencies, buildPythonPackage also injects
   # code into and wraps executables with the paths included in this list.
   # Items listed in install_requires go here
-  propagatedBuildInputs = resolveInputs attrs.propagatedBuildInputs or (_: [ ]);
+  propagatedBuildInputs = resolveInputs "propagatedBuildInputs" attrs.propagatedBuildInputs or (_: [ ]);
 
   doCheck = false;
 
@@ -163,4 +163,4 @@ pythonPkgs.buildPythonPackage (attrs // {
     mkdir -p $out/nedryland
     touch $out/nedryland/add-to-mypy-path
   '';
-})
+}))

--- a/languages/python/utils.nix
+++ b/languages/python/utils.nix
@@ -1,8 +1,7 @@
+base:
 {
-  resolveInputs = pythonPkgs: inputs:
-    if builtins.isFunction inputs then
-      (builtins.map
-        (input: if input ? isNedrylandComponent then input.package else input)
-        (inputs pythonPkgs))
-    else (builtins.map (input: if input ? isNedrylandComponent then input.package else input) inputs);
+  resolveInputs = pythonPkgs: name: typeName: inputs:
+    base.resolveInputs name typeName [ "package" ] (if builtins.isFunction inputs then
+      (inputs pythonPkgs)
+    else inputs);
 }

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -70,29 +70,11 @@ let
     }
   '';
 
-  resolveBuildInputs = typeName: builtins.map
-    (input:
-      if input ? isNedrylandComponent then
-        input."${componentTargetName}"
-          or input.package
-          or (abort "${name} could not auto-detect target for ${typeName} \"${input.name}\", please specify manually (tried \"${componentTargetName}\" and \"package\")")
-      else
-        input
-    );
-
-  resolveNativeBuildInputs = typeName: builtins.map
-    (input:
-      if input ? isNedrylandComponent then
-        input.package or (abort "${name} could not find \"package\" target for ${typeName} \"${input.name}\", please specify manually")
-      else
-        input
-    );
-
-  buildInputs = resolveBuildInputs "buildInput" attrs.buildInputs or [ ];
-  propagatedBuildInputs = resolveBuildInputs "propagatedBuildInput" attrs.propagatedBuildInputs or [ ];
-  shellInputs = resolveNativeBuildInputs "shellInput" attrs.shellInputs or [ ];
-  nativeBuildInputs = resolveNativeBuildInputs "nativeBuildInput" attrs.nativeBuildInputs or [ ];
-  checkInputs = resolveNativeBuildInputs "checkInput" attrs.checkInputs or [ ];
+  buildInputs = base.resolveInputs name "buildInputs" [ componentTargetName "package" ] attrs.buildInputs or [ ];
+  propagatedBuildInputs = base.resolveInputs name "propagatedBuildInputs" [ componentTargetName "package" ] attrs.propagatedBuildInputs or [ ];
+  shellInputs = base.resolveInputs name "shellInputs" [ "package" ] attrs.shellInputs or [ ];
+  nativeBuildInputs = base.resolveInputs name "nativeBuildInputs" [ "package" ] attrs.nativeBuildInputs or [ ];
+  checkInputs = base.resolveInputs name "checkInputs" [ "package" ] attrs.checkInputs or [ ];
 
   vendor = import ./vendor.nix pkgs rustBin {
     inherit name buildInputs propagatedBuildInputs;

--- a/test/mock-base.nix
+++ b/test/mock-base.nix
@@ -8,4 +8,6 @@ rec {
   mkService = mkComponent;
   mkClient = mkComponent;
   mkLibrary = mkComponent;
+  resolveInputs = _: _: _: inputs:
+    inputs;
 }


### PR DESCRIPTION
If component targets are aliases of each other they now maintain that
relationship when checks are enabled. Furthermore `base.enableChecks`
is not a function that enables checks on a component and
`base.checksEnabled` is now a flag that tells if checks are enabled on
the matrix.