### PR TITLE
🐛 Fix shells in Nedryland 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Shells works again
+
 ## [5.0.0] - 2022-02-22
 
 ### Fixed

--- a/shells.nix
+++ b/shells.nix
@@ -1,4 +1,10 @@
-{ pkgs, components, mapComponentsRecursive, parseConfig, enableChecksOnComponent, extraShells ? { } }:
+{ pkgs
+, components
+, mapComponentsRecursive
+, parseConfig
+, enableChecks
+, extraShells ? { }
+}:
 let
   config = parseConfig {
     key = "shells";
@@ -20,18 +26,18 @@ let
 in
 (mapComponentsRecursive
   (
-    _: component':
+    _: component:
       (
         let
-          # we want the check version of the component for
-          # the shell (but not for dependencies of it)
-          # that is the reason we are not using the check
-          # variant of the matrix
-          component = enableChecksOnComponent component';
           derivationShells =
             builtins.mapAttrs
-              (name: drv:
+              (name: drv':
                 let
+                  # we want the check version of the derivation for
+                  # the shell (but not for dependencies of it)
+                  # that is the reason we are not using the check
+                  # variant of the matrix
+                  drv = enableChecks drv';
                   targetName = "${component.name}.${name}";
                   shellPkg = (drv.drvAttrs // {
                     inherit (drv) passthru;


### PR DESCRIPTION
Shells needed a function to enable checks on the particular leaf node
that we want a shell for. This provides it with that again.