### PR TITLE
🐛 Fix non existing default shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Error occuring when no default shell could be picked.
 - Use default python version in clients and services.
 
 ## [5.0.1] - 2022-02-22

--- a/shells.nix
+++ b/shells.nix
@@ -97,7 +97,13 @@ in
             if (builtins.length (builtins.attrValues derivationShells)) == 1 then
               builtins.head (builtins.attrValues derivationShells)
             else
-              derivationShells."${config.defaultTarget}";
+              derivationShells."${config.defaultTarget}" or (pkgs.mkShell {
+                shellHook = ''
+                  echo -e "🐚 \e[32;4;31mCould not decide on a default shell\033[0m for component \"${component.name}\""
+                  echo -e "🎯 Available targets are: \033[1m${builtins.concatStringsSep ", " (builtins.attrNames derivationShells)}\033[0m"
+                  exit 1
+                '';
+              });
         in
         defaultShell.overrideAttrs (_: {
           passthru = derivationsAndAttrsets;


### PR DESCRIPTION
There was a case where the component did not have a default target and
had more than one shell. In those cases it can't decide which shell to
pick. Made it create a shell that gives the user an error and
providing it with the available shells and then exiting the shell.