### PR TITLE
🔧 Make pylint less sensitive to duplicate code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error occuring when no default shell could be picked.
 - Use default python version in clients and services.
 
+### Changed
+- Default pylintrc: increase threshold for duplicate-code check, 4->16.
+- Default pylintrc: skip imports for duplicate-code check.
+
 ## [5.0.1] - 2022-02-22
 
 ### Fixed

--- a/languages/python/pylintrc
+++ b/languages/python/pylintrc
@@ -356,10 +356,10 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=16
 
 
 [BASIC]


### PR DESCRIPTION
Default settings increased, they are too strict and it can't be ignored
with comments: https://github.com/PyCQA/pylint/issues/214 this is fixed
in 2.13.0.