### PR TITLE
🔧 🐛 Fix pylintrc issues regarding similar lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Pylint: Disabe R0801, since it's broken in current version
+- Python: extendFile now writes out pylintrc files as .pylintrc
+
 ## [5.0.2] - 2022-03-25
 
 ### Fixed

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -66,10 +66,10 @@ let
 
   pylintrc = ''
     ${extendFile {
-      filePath = "pylintrc";
+      filePath = ".pylintrc";
       baseFile = ./pylintrc;
       inherit name;
-      }}/pylintrc
+      }}/.pylintrc
   '';
 
   attrs = builtins.removeAttrs args [ "srcExclude" "shellInputs" "targetSetup" "docs" ];

--- a/languages/python/pylintrc
+++ b/languages/python/pylintrc
@@ -141,7 +141,8 @@ disable=no-member,
         exception-escape,
         comprehension-escape,
         C0330,
-        fixme
+        fixme,
+        R0801 # Because of this: https://github.com/PyCQA/pylint/issues/4118 fixed in pylint 2.10
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Also write pylintrc as .pylintrc in extendFile for consistency.