### PR TITLE
🐛 Fix python shellCommands and targetSetup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Python components can take `targetSetup` as a derivation (preferably made with `base.mkTargetSetup`) as well as a set of overrides.
+- `shellCommands` for python components works like the others (can take a set with command_name = bash_code;).
+
 ## [6.0.0] - 2022-04-29
 
 ### Added


### PR DESCRIPTION
Python does not use mkDerivation, it uses buildPythonPackage so
shellCommands are not propagated.

Also allow target setup for python to be a complete target setup and not
only override individual parts of it.