### PR TITLE
💄 Make targetSetup's file tree view show varaibles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python components can take `targetSetup` as a derivation (preferably made with `base.mkTargetSetup`) as well as a set of overrides.
 - `shellCommands` for python components works like the others (can take a set with command_name = bash_code;).
 - `shellCommands` input for rust components are merged with default.
+- targetSetup expands variables in template files for the file tree preview.
 
 ## [6.0.0] - 2022-04-29
 

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -112,7 +112,7 @@ base.enableChecks (pythonPkgs.buildPythonPackage (attrs // {
 
   targetSetup = if (args ? targetSetup && lib.isDerivation args.targetSetup) then args.targetSetup else
   (base.mkTargetSetup {
-    name = args.targetSetup.name or "python";
+    name = args.targetSetup.name or args.name;
     markerFiles = args.targetSetup.markerFiles or [ ] ++ [ "setup.py" "setup.cfg" "pyproject.toml" ];
     templateDir = pkgs.symlinkJoin {
       name = "python-component-template";

--- a/targetsetup.nix
+++ b/targetsetup.nix
@@ -33,6 +33,7 @@ pkgs.writeTextFile {
     ''
       source $stdenv/setup > /dev/null 
       componentSetup() {
+        ${vars}
         echo ""
         echo "👋 Hello! It looks like you are in a new ${name} component, lets do some setup!"
         if [ "${templateDir'}" != "" ] && [ "${builtins.toString showTemplate}" == "1" ]; then
@@ -53,7 +54,6 @@ pkgs.writeTextFile {
           return 0
         fi
 
-        ${vars}
         ${readVarStdin}
 
         for rel in $(find ${templateDir'} -type f,l | sed 's|${templateDir'}/||g'); do


### PR DESCRIPTION
Also make the nix name of the targetSetup derivation more readable.

The variables were just exported too late.