### PR TITLE
⚡ Make targetSetup better with marker files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `shellCommands` input for rust components are merged with default.
 - targetSetup expands variables in template files for the file tree preview.
 
+### Added
+- `targetSetup` can now use `@variableName@` in the `markerFiles` argument.
+- `markerFiles` in `targetSetup` can now also be folders (or sockets or any other kind of file).
+
 ## [6.0.0] - 2022-04-29
 
 ### Added

--- a/targetsetup.nix
+++ b/targetsetup.nix
@@ -33,7 +33,6 @@ pkgs.writeTextFile {
     ''
       source $stdenv/setup > /dev/null 
       componentSetup() {
-        ${vars}
         echo ""
         echo "👋 Hello! It looks like you are in a new ${name} component, lets do some setup!"
         if [ "${templateDir'}" != "" ] && [ "${builtins.toString showTemplate}" == "1" ]; then
@@ -57,7 +56,6 @@ pkgs.writeTextFile {
         ${readVarStdin}
 
         for rel in $(find ${templateDir'} -type f,l | sed 's|${templateDir'}/||g'); do
-          #rel=$(realpath --relative-to="${templateDir'}" "$file")
           file=${templateDir'}/$rel
           outname=$(echo $rel | sed -E 's!@(\w+)@!''${\1}!g' | ${pkgs.envsubst}/bin/envsubst)
           if [ -f $outname ]; then
@@ -70,10 +68,12 @@ pkgs.writeTextFile {
         done
         ${initCommands}
       }
+      ${vars}
       markers=(${builtins.concatStringsSep " " markerFiles})
       markerFound=false
       for marker in ''${markers[@]};do
-        if [ -f "$marker" ]; then
+        filename=$(echo $marker | sed -E 's!@(\w+)@!''${\1}!g' | ${pkgs.envsubst}/bin/envsubst)
+        if [ -e "$filename" ]; then
           markerFound=true
           break
         fi


### PR DESCRIPTION
Can now be any kind of file (-e instead of -f) and can use variables
with the substitute syntax (@variable@) like the template files.