### PR TITLE
⚡ Support Google style docstrings for Sphinx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Sphinx documentation generation now supports Google-style docstrings thanks to the Napoleon extension shipped with Sphinx.
+- Sphinx documentation can now pick up extra extensions from the config `[python] sphinx-extensions = [ "sphinx.ext.imgmath" ]`
 - `shellCommands` can take sets with "script", "description", "args" and "show" to generate the shell welcome message for the command.
 
 ### Changed Versions

--- a/examples/documentation/client/awesome_client/main.py
+++ b/examples/documentation/client/awesome_client/main.py
@@ -2,5 +2,12 @@
 
 
 def main(value_1: int, value_2: int) -> int:
-    """main function of awesome_client"""
+    """main function of awesome_client
+
+    Args:
+        value_1 (int): a value to add to value_2.
+        value_2 (int): the value that value_1 is added to.
+    Returns:
+        int: The sum of the two values.
+    """
     return value_1 + value_2

--- a/languages/python/docs.nix
+++ b/languages/python/docs.nix
@@ -10,6 +10,7 @@ let
       python = {
         generator = "sphinx";
         sphinx-theme = "";
+        sphinx-extensions = [ ];
       };
       author = "";
       authors = [ ];
@@ -80,6 +81,8 @@ in
 
       mkdir -p doc-source
       echo "" >> doc-source/conf.py # generated conf.py does not end in a newline
+      sed -i -r 's/(extensions = \[)/\1${builtins.concatStringsSep "," (builtins.map (s: ''"${s}"'') (docsConfig.python.sphinx-extensions ++ [ "sphinx.ext.napoleon" ]))},/g' doc-source/conf.py
+      echo "napoleon_include_init_with_doc = True" >> doc-source/conf.py
       ${if sphinxTheme != null then "echo ${sphinxTheme.conf} >> doc-source/conf.py" else "" }
       ${if logo != { } then "echo 'html_logo = \"${logo.source or logo.path}\"' >> doc-source/conf.py" else ""}
     '';


### PR DESCRIPTION
When generating API docs for Python code with Sphinx, enable the
Napoleon extension that provides support for parsing Google-style
docstrings.