### PR TITLE
⚡ Add components (all components) to extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `targetSetup` can now use `@variableName@` in the `markerFiles` argument.
 - `markerFiles` in `targetSetup` can now also be folders (or sockets or any other kind of file).
+- Base extensions can now depend on `components` to get a set of all components.
 
 ## [6.0.0] - 2022-04-29
 

--- a/default.nix
+++ b/default.nix
@@ -196,7 +196,7 @@ in
                 pkgs.lib.recursiveUpdate combinedBaseExtensions (if builtins.isAttrs currentBaseExtension then currentBaseExtension else
                 (
                   extFn (
-                    builtins.intersectAttrs args components //
+                    builtins.intersectAttrs args (components // { inherit components; }) //
                     builtins.intersectAttrs args pkgs // {
                       base = (pkgs.lib.recursiveUpdate combinedBaseExtensions initialBase);
                     }


### PR DESCRIPTION
Extensions can now depend on `components` to get a set of all compoents,
just like components themselves can.