### PR TITLE
🐛 Revert "🐛 Fix doCheck not skipping checks"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - prost-build from 0.9.0 to 0.10.4 for protobuf
 - tonic from 0.6.1 to 0.7.2
 
-### Fixed
-- doCheck attribute for components now disable checks when set to false.
-
 ## [6.1.0] - 2022-06-16
 
 ### Fixed

--- a/default.nix
+++ b/default.nix
@@ -100,15 +100,13 @@ in
             mkComponent' = mkComponent minimalBase.deployment.mkCombinedDeployment parseConfig;
             parseConfig = import ./config.nix pkgs configContent configRoot (pkgs.lib.toUpper name);
             enableChecksOverride = enable: drv:
-              if enable && !(drv.nedrylandChecksEnabled or false) && (drv.doCheck or true) then
+              if enable && !(drv.doCheck or false) then
                 drv.overrideAttrs
                   (oldAttrs: {
                     doCheck = true;
 
                     # Python packages don't have a checkPhase, only an installCheckPhase
                     doInstallCheck = true;
-
-                    nedrylandChecksEnabled = true;
                   } // pkgs.lib.optionalAttrs (drv.stdenv.hostPlatform != drv.stdenv.buildPlatform && oldAttrs.doCrossCheck or false) {
                     preInstallPhases = [ "crossCheckPhase" ];
                     crossCheckPhase = oldAttrs.checkPhase or "";

--- a/languages/rust/default.nix
+++ b/languages/rust/default.nix
@@ -263,5 +263,9 @@ rec {
         name = "${name}-rust-protobuf";
         src = generatedCode;
         propagatedBuildInputs = builtins.map (pi: pi.rust.package) protoInputs;
+
+        # Disabling the check phase as we do not care about
+        # formatting or testing generated code.
+        checkPhase = "";
       };
 }


### PR DESCRIPTION
This reverts commit af4a8a02b63d8733f3b6c0a5db69d5bb3bf6de34. This
solution never really worked. Now checks could NEVER be run, because
`stdenv.mkDerivation` sets doCheck to what is sent in or false. So
we can never know if the user set the attribute or nixpkgs did.