### PR TITLE
✨ 📚 Show shellCommands and their description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `shellCommands` can take sets with "script", "description", "args" and "show" to generate the shell welcome message for the command.
+
 ### Changed Versions
 - prost-build from 0.9.0 to 0.10.4 for protobuf
 - tonic from 0.6.1 to 0.7.2
+
+### Fixed
+- shellCommands does not print any internal setup.
 
 ## [6.1.0] - 2022-06-16
 

--- a/documentation/mdbook.nix
+++ b/documentation/mdbook.nix
@@ -11,11 +11,11 @@ base.mkDerivation (attrs // {
     cp -r book/. $out/share/doc/${name}/${type}
   '';
   shellCommands = {
-    run = ''mdbook serve --port ''${1:-3000} "$@" &'';
+    run = {
+      script = ''mdbook serve --port ''${1:-3000} "$@" &'';
+      description = ''
+        Preview the book and watches the book's src directory for changes, rebuilding the book and refreshing clients for each change.
+      '';
+    };
   };
-
-  shellHook = ''
-    echo -e "Use \033[1mrun\033[0m to look at the book in a webbrowser, which updates on file save"
-    ${attrs.shellHook or ""}
-  '';
 })

--- a/documentation/mkdocs.nix
+++ b/documentation/mkdocs.nix
@@ -12,9 +12,9 @@ base.mkDerivation (attrs // {
     cp -r site/. $out/share/doc/${name}/${type}
   '';
   shellCommands = {
-    run = ''mkdocs serve "$@" &'';
+    run = {
+      script = ''mkdocs serve "$@" &'';
+      description = "Look at the docs in a web browser, which updates on file save";
+    };
   };
-  shellHook = ''
-    echo -e "Use \033[1mrun\033[0m to look at the docs in a webbrowser, which updates on file save"
-  '';
 })

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -136,8 +136,18 @@ base.enableChecks (pythonPkgs.buildPythonPackage (attrs // {
   });
 
   shellCommands = base.mkShellCommands name ({
-    check = ''eval $installCheckPhase'';
-    format = "black . && isort .";
+    check = {
+      script = ''eval $installCheckPhase'';
+      description = "Run lints and tests.";
+    };
+    format = {
+      script = "black . && isort .";
+      description = "Format the code.";
+    };
+    build = {
+      script = ''eval $buildPhase'';
+      show = false;
+    };
   } // attrs.shellCommands or { });
 
   shellHook = ''

--- a/languages/rust/package.nix
+++ b/languages/rust/package.nix
@@ -138,9 +138,20 @@ base.mkDerivation
     safeAttrs // {
       inherit stdenv propagatedBuildInputs checkInputs;
       shellCommands = {
-        run = ''cargo run "$@"'';
-        format = ''cargo fmt'';
-        debug = ''RUST_DEBUG=1 "$@"'';
+        run = {
+          script = ''cargo run "$@"'';
+          description = "Run the application.";
+          args = "args ...";
+        };
+        format = {
+          script = ''cargo fmt'';
+          description = "Format the code.";
+        };
+        debug = {
+          script = ''RUST_DEBUG=1 "$@"'';
+          description = "Run a command with RUST_DEBUG set.";
+          args = "command args ...";
+        };
       } // safeAttrs.shellCommands or { };
       strictDeps = true;
       disallowedReferences = [ vendor ];

--- a/shells.nix
+++ b/shells.nix
@@ -72,6 +72,11 @@ in
                       echo 🐚 Running shell hook for \"${targetName}\"
                       ${drv.shellHook or ""}
                       echo 🥂 You are now in a shell for working on \"${targetName}\"
+                      esc=$(printf '\e[')
+                      echo "Available commands for this shell are:"
+                      ${builtins.concatStringsSep "\n" (pkgs.lib.mapAttrsToList (name: desc:
+                        ''echo "  ''${esc}32m${name}''${esc}0m ''${esc}33m${desc.args}''${esc}0m" ${if desc.description != "" then '';echo "    ${builtins.replaceStrings ["\n"] ["\n    "] desc.description}"'' else ""}'')
+                        (pkgs.lib.filterAttrs (_: value: value.show) drv.shellCommands._descriptions))}
                     '';
                   });
                 in


### PR DESCRIPTION
Also silence the sourcing of the shellCommands' environment.
When entering a shell, list the commands and their description. Example:
```
shellCOmmands = {
    command-name = {
        script = "code...";
        description = ''
          Very good description.
          Can be multi line
        '';
        args = "-h --help";
    };
    secret-command-name = {
        script = "code...";
        # This command is not listed in welcome message
        show = false;
    };
    simple-command = "code...";
};
```