### PR TITLE
🐛 Fix shells for docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - shellCommands does not print any internal setup.
+- Shells for `docs` derivations now works again, and the `doc` target itself warns that it is not a useful shell.
 
 ## [6.1.0] - 2022-06-16
 


### PR DESCRIPTION
Docs are derivations in derivations, not derivations in components so
they are missed by collectComponentsRecursive nad did not get any
shells. Now we add on shells for them specifically and add a warning
that the `docs` shell itself it not valid since it's just the
symlinkJoin without anything useful.

Fixes #281 