### PR TITLE
🐛 🔨 Change docs to be treated as components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- To get all the documentation you now need to call it on the .all target since docs is a component now.
+
 ### Added
 - Sphinx documentation generation now supports Google-style docstrings thanks to the Napoleon extension shipped with Sphinx.
 - Sphinx documentation can now pick up extra extensions from the config `[python] sphinx-extensions = [ "sphinx.ext.imgmath" ]`
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - shellCommands does not print any internal setup.
+- Shelling into documentation.
 
 ## [6.1.0] - 2022-06-16
 

--- a/docs.nix
+++ b/docs.nix
@@ -1,0 +1,25 @@
+pkgs: mkComponent:
+pkgs.lib.makeOverridable (targets: ({
+  _isNedrylandCombinedDocs = true;
+  resolve = (name:
+    let
+      resolvedDocDrvs = builtins.mapAttrs
+        (key: func:
+          func.docFunction name key)
+        (pkgs.lib.filterAttrs (_: v: builtins.isAttrs v && v ? docFunction) targets);
+      attrsWithResolvedDocDrvs = targets // resolvedDocDrvs;
+    in
+    mkComponent
+      (attrsWithResolvedDocDrvs // {
+        inherit name;
+        all = pkgs.symlinkJoin {
+          name = "${name}-all-documentation";
+          paths = builtins.attrValues resolvedDocDrvs ++ (builtins.filter pkgs.lib.isDerivation (builtins.attrValues targets));
+          postBuild = ''
+            mkdir -p $out/share/doc/${name}/
+            echo '${builtins.toJSON  attrsWithResolvedDocDrvs}' > $out/share/doc/${name}/metadata.json
+          '';
+        };
+        nedrylandType = "documentation";
+      }));
+} // pkgs.lib.optionalAttrs (targets ? "name") { inherit (targets) name; }))

--- a/documentation/default.nix
+++ b/documentation/default.nix
@@ -15,7 +15,7 @@ in
 
 builtins.mapAttrs
   (_: f: attrs: {
-    docfunction = (name: type: (f ({ inherit name type; } // attrs)));
+    docFunction = name: type: (f ({ inherit name type; } // attrs));
   })
 rec {
   mkProjectDocs =

--- a/test/docs.nix
+++ b/test/docs.nix
@@ -1,5 +1,5 @@
 pkgs: docMatrix:
-pkgs.runCommand "test-doc-out-path" { outPath = docMatrix.awesomeClient.docs; jason = pkgs.jq; } ''
+pkgs.runCommand "test-doc-out-path" { outPath = docMatrix.awesomeClient.docs.all; jason = pkgs.jq; } ''
   set -e
   touch $out
   assertPathExists() {

--- a/test/rust-cross.nix
+++ b/test/rust-cross.nix
@@ -16,15 +16,15 @@ assert assertMsg (builtins.length crossRust.rust == 2) "Expected crossRust to ha
 # Docs
 # Have to change these tests later when we combine all docs to a single target.
 assert assertMsg (baseRust ? docs.api) "Expected baseRust to contain api docs in `docs.api`";
-assert assertMsg (lib.isDerivation baseRust.docs) "Expected baseRust.docs to be a derivation";
+assert assertMsg (baseRust.docs ? isNedrylandComponent) "Expected baseRust.docs to be a Nedryland component";
 assert assertMsg (lib.isDerivation baseRust.docs.api) "Expected baseRust.docs.api to be a derivation";
 
 assert assertMsg (windowsRust ? docs.api) "Expected windowsRust to contain api docs in `docs.api`";
-assert assertMsg (lib.isDerivation windowsRust.docs) "Expected windowsRust.docs to be a derivation";
+assert assertMsg (windowsRust.docs ? isNedrylandComponent) "Expected windowsRust.docs to be a Nedryland component";
 assert assertMsg (lib.isDerivation windowsRust.docs.api) "Expected windowsRust.docs.api to be a derivation";
 
 assert assertMsg (crossRust ? docs.api) "Expected crossRust to contain docs.";
-assert assertMsg (lib.isDerivation crossRust.docs) "Expected crossRust.docs to be a derivation";
+assert assertMsg (crossRust.docs ? isNedrylandComponent) "Expected crossRust.docs to be a Nedryland component";
 assert assertMsg (lib.isDerivation crossRust.docs.api) "Expected crossRust.docs.api to be a derivation";
 
 # buildInput propagation tests


### PR DESCRIPTION
- Fixes bug where you could not enter shells for documentation.
- Changes docs to be a component in a backwards compatible manner. If
  docs is just a set it will convert it to the new form.
- Shells work out of the box like all other components.