### PR TITLE
📚 Update changelog with backport release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed Versions
+- prost-build from 0.9.0 to 0.10.4 for protobuf
+- tonic from 0.6.1 to 0.7.2
+
+# [6.2.0] - 2022-07-11
+
 ### Added
 - Sphinx documentation generation now supports Google-style docstrings thanks to the Napoleon extension shipped with Sphinx.
 - Sphinx documentation can now pick up extra extensions from the config `[python] sphinx-extensions = [ "sphinx.ext.imgmath" ]`
 - `shellCommands` can take sets with "script", "description", "args" and "show" to generate the shell welcome message for the command.
-
-### Changed Versions
-- prost-build from 0.9.0 to 0.10.4 for protobuf
-- tonic from 0.6.1 to 0.7.2
 
 ### Fixed
 - shellCommands does not print any internal setup.


### PR DESCRIPTION
6.2.0 was released by cherry picking commits but skipping the breaking
changes of tonic and prost-build.