### PR TITLE
🐛 Fix shellCommands for terraform components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `mkDerivation` now uses the default shellCommands in `base.mkShellCommands` if none are supplied.
+- Terraform components can define shellCommands.
+
 ### Changed Versions
 - prost-build from 0.9.0 to 0.10.4 for protobuf
 - tonic from 0.6.1 to 0.7.2
@@ -18,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `shellCommands` can take sets with "script", "description", "args" and "show" to generate the shell welcome message for the command.
 
 ### Fixed
-- `mkDerivation` now uses the default shellCommands in `base.mkShellCommands` if none are supplied.
 - shellCommands does not print any internal setup.
 - Shells for `docs` derivations now works again, and the `doc` target itself warns that it is not a useful shell.
 

--- a/languages/terraform/default.nix
+++ b/languages/terraform/default.nix
@@ -16,7 +16,7 @@
     , ...
     }:
     let
-      attrs = (builtins.removeAttrs attrs' [ "variables" "srcExclude" "subComponents" ]);
+      attrs = (builtins.removeAttrs attrs' [ "variables" "srcExclude" "subComponents" "shellCommands" ]);
       terraformPkg = pkgs."${versions.terraform}";
     in
     base.mkComponent rec {
@@ -72,7 +72,7 @@
               ${postTerraformHook}'';
             show = false;
           };
-        } // attrs.shellCommands or { };
+        } // attrs'.shellCommands or { };
 
         shellHook = ''
           ${if disableApplyInShell then ''echo "❕ Note that terraform apply is disabled in this shell."'' else ""}


### PR DESCRIPTION
The deploy phase would try to make environment variables out of the set
which it can't.