### PR TITLE
⚡ 🐎 Make ci shellcheck faster and more accurate

### DIFF
--- a/.github/workflows/setup/setup-builders-ssh.sh
+++ b/.github/workflows/setup/setup-builders-ssh.sh
@@ -1,3 +1,4 @@
+#! /usr/bin/env sh
 sudo --preserve-env=SSH_AUTH_SOCK \
 ssh -T -o StrictHostKeyChecking=accept-new \
 root@nix-builders.goodbyekansas.com 'nix-store --version && echo "connection successful"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mkDerivation` now uses the default shellCommands in `base.mkShellCommands` if none are supplied.
 - Terraform components can define shellCommands.
 
+### Changed
+- shellcheck from the ci attribute will now find more shell scripts and is faster.
+
 ### Changed Versions
 - prost-build from 0.9.0 to 0.10.4 for protobuf
 - tonic from 0.6.1 to 0.7.2

--- a/ci/shellcheck.bash
+++ b/ci/shellcheck.bash
@@ -1,19 +1,10 @@
 #! /usr/bin/env bash
 
-is_bash() {
-    [[ $1 == *.sh ]] && return 0
-    [[ $1 == */bash-completion/* ]] && return 0
-    [[ $(file -b --mime-type "$1") == text/x-shellscript ]] && return 0
-    return 1
-}
-
 EXIT_CODE=0
 
-while IFS= read -r -d $'' file; do
-    if ! git check-ignore -q "$file" && is_bash "$file"; then
-        @shellcheck@ -W0 -s bash "$@" "$file"
-        EXIT_CODE=$((EXIT_CODE + $?))
-    fi
-done < <(find . -type f \! -path "./.git/*" -print0)
+while IFS= read -r script; do
+    @shellcheck@ "$script"
+    EXIT_CODE=$((EXIT_CODE + $?))
+done < <(@shfmt@ -f .)
 
 exit $EXIT_CODE

--- a/default.nix
+++ b/default.nix
@@ -63,6 +63,7 @@ in
       diff = "${pkgs.diffutils}/bin/diff";
       mktemp = "${pkgs.mktemp}/bin/mktemp";
       shellcheck = "${pkgs.shellcheck}/bin/shellcheck";
+      shfmt = "${pkgs.shfmt}/bin/shfmt";
       nixLinter = "${pkgs.nix-linter}/bin/nix-linter";
       # Pointless to do this on a remote machine.
       preferLocalBuild = true;

--- a/languages/rust/protobuf/compiler/changeTonicBuildVersion.sh
+++ b/languages/rust/protobuf/compiler/changeTonicBuildVersion.sh
@@ -1,3 +1,4 @@
+#! /usr/bin/env bash
 changeTonicBuildVersion() {
     sed -i 's/tonic-build.*$/tonic-build = "@tonicBuildVersion@"/g' Cargo.toml
 }


### PR DESCRIPTION
Use shfmt for finding shell scripts, it is better and faster than the
find + function.