### PR TITLE
⚡ Don't include the tests folder in python wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mkDerivation` now uses the default shellCommands in `base.mkShellCommands` if none are supplied.
 - Terraform components can define shellCommands.
 - Generated setup.py files in python components excludes the generated tests folder.
+- documentation derivations now merges `shellCommands` correctly.
+- Python components' `nativeBuildInputs` and `checkInputs` now resolve lists properly
+  again.
 
 ### Changed
 - shellcheck from the ci attribute will now find more shell scripts and is faster.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `mkDerivation` now uses the default shellCommands in `base.mkShellCommands` if none are supplied.
 - Terraform components can define shellCommands.
+- Generated setup.py files in python components excludes the generated tests folder.
 
 ### Changed
 - shellcheck from the ci attribute will now find more shell scripts and is faster.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `documentation.mkSinglePage` now runs `preBuild`, `postBuild`, `preInstall` and `postInstall` hooks.
+
 ### Fixed
 - `mkDerivation` now uses the default shellCommands in `base.mkShellCommands` if none are supplied.
 - Terraform components can define shellCommands.

--- a/documentation/mdbook.nix
+++ b/documentation/mdbook.nix
@@ -17,5 +17,5 @@ base.mkDerivation (attrs // {
         Preview the book and watches the book's src directory for changes, rebuilding the book and refreshing clients for each change.
       '';
     };
-  };
+  } // attrs.shellCommands or { };
 })

--- a/documentation/mkdocs.nix
+++ b/documentation/mkdocs.nix
@@ -16,5 +16,5 @@ base.mkDerivation (attrs // {
       script = ''mkdocs serve "$@" &'';
       description = "Look at the docs in a web browser, which updates on file save";
     };
-  };
+  } // attrs.shellCommands or { };
 })

--- a/languages/python/component-template/setup.py
+++ b/languages/python/component-template/setup.py
@@ -8,6 +8,6 @@ setup(
     author="@author@",
     author_email="@email@",
     description="@desc@",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     entry_points=@entryPoint@,
 )

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -78,16 +78,9 @@ base.enableChecks (pythonPkgs.buildPythonPackage (attrs // {
   inherit src version setupCfg pylintrc format preBuild doStandardTests;
   pname = name;
 
-  # Dependencies needed for running the checkPhase. These are added to nativeBuildInputs when doCheck = true. Items listed in tests_require go here.
-  checkInputs = (resolveInputs "checkInputs" attrs.checkInputs or [ ]);
-
   # Build and/or run-time dependencies that need to be be compiled
   # for the host machine. Typically non-Python libraries which are being linked.
   buildInputs = resolveInputs "buildInputs" attrs.buildInputs or [ ];
-
-  # Build-time only dependencies. Typically executables as well
-  # as the items listed in setup_requires
-  nativeBuildInputs = resolveInputs "nativeBuildInputs" attrs.nativeBuildInputs or [ ];
 
   passthru = {
     shellInputs = (resolveInputs "shellInputs" args.shellInputs or [ ])


### PR DESCRIPTION
Unit tests runs on the source so there's no need to include the tests
folder in the wheel. Nix already strips it from the package. Having all
packages install a tests folder in site-packages will just override each
other.

We generate the tests folder so it seems nice to also be the ones to
exclude it.

Note that this is just the template for new components and does not
affect existing components.