### PR TITLE
🐛 Fix usage of resolveInputs in python components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - shellCommands does not print any internal setup.
 - Shells for `docs` derivations now works again, and the `doc` target itself warns that it is not a useful shell.
+- Python components' `nativeBuildInputs` and `checkInputs` now resolve lists properly again.
 
 ## [6.1.0] - 2022-06-16
 

--- a/languages/python/package.nix
+++ b/languages/python/package.nix
@@ -78,16 +78,9 @@ base.enableChecks (pythonPkgs.buildPythonPackage (attrs // {
   inherit src version setupCfg pylintrc format preBuild doStandardTests;
   pname = name;
 
-  # Dependencies needed for running the checkPhase. These are added to nativeBuildInputs when doCheck = true. Items listed in tests_require go here.
-  checkInputs = (resolveInputs "checkInputs" attrs.checkInputs or [ ]);
-
   # Build and/or run-time dependencies that need to be be compiled
   # for the host machine. Typically non-Python libraries which are being linked.
   buildInputs = resolveInputs "buildInputs" attrs.buildInputs or [ ];
-
-  # Build-time only dependencies. Typically executables as well
-  # as the items listed in setup_requires
-  nativeBuildInputs = resolveInputs "nativeBuildInputs" attrs.nativeBuildInputs or [ ];
 
   passthru = {
     shellInputs = (resolveInputs "shellInputs" args.shellInputs or [ ])


### PR DESCRIPTION
Use resolveInputs the first time we hit `checkInputs` or
`nativeBuildInputs`, removed the resolve from package.nix since
mkPackage nowadays is an internal function so it does not need to be
resolved there as well.