### PR TITLE
⚡ 🐛 💎 Fix nix Python dependencies, 🍒 from in 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - prost-build from 0.9.0 to 0.10.4 for protobuf
 - tonic from 0.6.1 to 0.7.2
 
-# [6.2.0] - 2022-07-11
+## [6.3.0] - 2022-09-19
+
+### Fixed
+- Python dependencies not being discovered when running pip install. Since dependencies
+  are fetched with Nix, we instead tell pip to not "verify" them when doing the
+  installation. This was a problem for example for PySide2 and Shiboken.
+
+## [6.2.0] - 2022-07-11
 
 ### Added
 - Sphinx documentation generation now supports Google-style docstrings thanks to the Napoleon extension shipped with Sphinx.

--- a/languages/python/default.nix
+++ b/languages/python/default.nix
@@ -46,6 +46,11 @@ let
             nativeBuildInputs = (
               resolveInputs "nativeBuildInputs" attrs.nativeBuildInputs or [ ]
             ) ++ [ (hooks.mypy pyPkgs.python) ];
+
+            # Don't install dependencies with pip, let nix handle that
+            preInstall = ''
+              pipInstallFlags+=('--no-deps')
+            '';
           }));
         in
         if buildWheel then addWheelOutput pkg else pkg;


### PR DESCRIPTION
Some python packages in nixpkgs are not discoverable by pip (missing installinfo/egg_info) which causes problems for dependencies specified in `install_requires`. This commit makes Python work more akin to C++, where dependencies are specified once in Nix, to make sure they are present at build time and once in CMake/Make to actually depend on them. The python equivalent would be Nix to ensure prescence and `setup.py` to declare usage. This way of solving the problem also preserves the validity of the packages as normal Python packages.