### PR TITLE
⚡ Make mdbook more extendable and run better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `documentation.mkMdbook` run is now a shell function which creates an exit trap to shut down the server,
   also added open command to open the mdbook in a browser and a stop command to shut down the server.
 - `documentation.mkMdbook` run uses ephemeral port, allowing multiple shells to serve mdbooks simultaneously.
+- shells uses src if possible for "$componentDir" and fallbacks to nix file location.
 
 ## [7.0.0] - 2022-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `documentation.mkMdbook` uses pre/post hooks for build and install and let users add inputs.
+- `documentation.mkMdbook` run is now a shell function which creates an exit trap to shut down the server,
+  also added open command to open the mdbook in a browser and a stop command to shut down the server.
+- `documentation.mkMdbook` run uses ephemeral port, allowing multiple shells to serve mdbooks simultaneously.
+
 ## [7.0.0] - 2022-11-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `documentation.mkMdbook` run uses ephemeral port, allowing multiple shells to serve mdbooks simultaneously.
 - shells uses src if possible for "$componentDir" and fallbacks to nix file location.
 
+### Fixed
+- When printing welcome text in shells, respect shellCommands' "show" attribute.
+
 ## [7.0.0] - 2022-11-24
 
 ### Added

--- a/documentation/mdbook-run.bash
+++ b/documentation/mdbook-run.bash
@@ -1,0 +1,31 @@
+ticker=("⢿" "⡿" "⣟" "⣯" "⣷" "⣾" "⣽" "⣻")
+tickerCount=0
+echo -n "📖 Starting mdbook... ${ticker[tickerCount]}"
+serveOutput=$(mktemp)
+mdbook serve --port "${1:-0}" "$@" 1>"$serveOutput" 2>&1 &
+servePid=$!
+servePort=""
+while ps -p $servePid >/dev/null && [ -z "$servePort" ]; do
+    if [ $((tickerCount % 2)) -eq 0 ]; then
+        servePort=$(sed -n -E 's/^.*listening on (.*)$/\1/p' "$serveOutput")
+    else
+        sleep 0.25
+    fi
+
+    tickerCount=$((tickerCount + 1))
+    tickerCount=$((tickerCount % ${#ticker[@]}))
+    echo -en "\b${ticker[tickerCount]}"
+done
+
+if ! ps -p $servePid >/dev/null; then
+    wait $servePid || true
+    echo "📒 mdbook exited with code: $?"
+    echo "Output:"
+    sed "s/^/  [ 📔 ] /" <"$serveOutput"
+    exit 1
+fi
+
+echo $servePid > ./run.pid
+echo "$servePort" >> ./run.pid
+echo ""
+echo "Mdbook running on $servePort"

--- a/documentation/mdbook.nix
+++ b/documentation/mdbook.nix
@@ -1,21 +1,81 @@
 pkgs: base: attrs@{ name, type ? "user", src, ... }:
 base.mkDerivation (attrs // {
   inherit name src;
-  buildInputs = [ pkgs.mdbook ];
+  nativeBuildInputs = [ pkgs.mdbook ] ++ attrs.nativeBuildInputs or [ ];
 
   buildPhase = ''
+    runHook preBuild
     mdbook build --dest-dir book
+    runHook postBuild
   '';
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/share/doc/${name}/${type}
     cp -r book/. $out/share/doc/${name}/${type}
+    runHook postInstall
+  '';
+  shellHook = ''
+    on_exit() {
+      if [ -f ./mdbook.pid ]; then
+        read -r -p "Mdbook is running, close? [Y/n] "
+        case $REPLY in
+          n|N|No|NO|no) ;;
+          *) kill -SIGTERM $(head -n 1 ./mdbook.pid); rm ./mdbook.pid ;;
+        esac
+      fi
+    }
+
+    run() {
+      trap on_exit SIGQUIT EXIT SIGHUP
+      command run 0 ./mdbook.pid
+    }
+
+    if checkRun; then
+      echo ""
+      echo -e "🏃‍♀️ You seem to be running mdbook already at \e[93m$(tail -n 1 ./mdbook.pid)\e[0m, use \e[32mopen\e[0m to show it in your browser."
+      echo ""
+    else
+      if [ -f ./mdbook.pid ]; then
+        rm ./mdbook.pid
+      fi
+    fi
+
+    ${attrs.shellHook or ""}
   '';
   shellCommands = {
     run = {
-      script = ''mdbook serve --port ''${1:-3000} "$@" &'';
+      script = ./mdbook-run.bash;
       description = ''
-        Preview the book and watches the book's src directory for changes, rebuilding the book and refreshing clients for each change.
-      '';
+        Preview the book and watches the book's src directory for changes, rebuilding the book and refreshing clients for each change.'';
     };
+
+    stop = {
+      script = ''
+        if checkRun; then
+          kill -SIGTERM $(head -n 1 ./mdbook.pid)
+          rm ./mdbook.pid
+        else
+          echo "Found no mdbook started in this shell."
+        fi
+      '';
+      description = "Stop mdbook started in this shell.";
+    };
+
+    open = {
+      script = ''
+        if [ ! -f ./mdbook.pid ]; then
+          run
+        fi
+        ${pkgs.xdg-utils}/bin/xdg-open $(tail -n 1 ./mdbook.pid) >/dev/null
+      '';
+      description = "Open the mdbook in your browser. Starts a mdbook serve if one isn't running already.";
+    };
+
+    checkRun = {
+      script = ''[ -f ./mdbook.pid ] && [[ $(ps -o cmd= -p $(head -n 1 ./mdbook.pid)) =~ "mdbook serve" ]]'';
+      show = false;
+    };
+
+    check = { show = false; };
   } // attrs.shellCommands or { };
 })

--- a/shell-commands.nix
+++ b/shell-commands.nix
@@ -36,7 +36,7 @@ let
 
         rm -rf "$envDir"
 
-        ${if builtins.isAttrs script then script.script else script}
+        ${if builtins.isAttrs script then script.script or "" else script}
       '')
       cmds;
     passthru = {
@@ -45,10 +45,9 @@ let
           {
             description = (if builtins.isAttrs value then value.description or "" else "");
             args = (if builtins.isAttrs value then value.args or "" else "");
-            show = (if builtins.isAttrs value then value.show or true else true);
           }
         )
-        allCommands;
+        (lib.filterAttrs (_: value: if builtins.isAttrs value then value.show or true else true) allCommands);
     };
   };
 in

--- a/shells.nix
+++ b/shells.nix
@@ -65,7 +65,11 @@ in
 
                     # set componentDir here to be able to access
                     # it inside the shell as $componentDir if we wish
-                    componentDir = builtins.toString component.path;
+                    componentDir =
+                      let
+                        possibleSources = lib.optionals (drv ? src) [ (drv.src.origSrc or null) drv.src ];
+                      in
+                      builtins.toString (lib.findFirst (p: p != null && !lib.isStorePath p) component.path possibleSources);
 
                     # the standard shell hook will:
                     # 1. change directory to the component dir


### PR DESCRIPTION
Run the expected hooks on build and install and let users extend buildInputs (when switching to nativeBuildInputs). Shadowed the run shellCommand with a shell function, this is so a trap can be defined in the shell to shut down mdbook when exiting the shell.

~If someone has a smart idea of how to use the shell command I'm all ears. Problem with just putting it there is that mdbook is started in the background from the shell command program, so the trap would either run to early (when `run` finishes) or not at all. Kept the shellCommand to get the printed description.~