### PR TITLE
🐛 Fix dependent project base ext eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Evaluation of base extensions for dependent project used the components derivation
+  instead of the attrset.
+
 ## [8.0.0] - 2023-01-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Check for oldest supported Nixpkgs version. Can be overridden when importing Nedryland
+  by passing `skipNixpkgsVersionCheck = true`.
+
 ### Fixed
 - Evaluation of base extensions for dependent project used the components derivation
   instead of the attrset.

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,10 @@ let
     });
   });
 
-  f = { pkgs }:
+  f = { pkgs, skipNixpkgsVersionCheck ? false }:
+    assert pkgs.lib.assertMsg
+      (!skipNixpkgsVersionCheck && pkgs.lib.versionAtLeast (builtins.replaceStrings [ "pre-git" ] [ "" ] (pkgs.lib.version or "0.0.0")) "22.05")
+      "Nedryland supports nixpkgs versions >= 22.05, you have ${pkgs.lib.version or "unknown"}}";
     let
       pkgs' = pkgs.extend gitIgnoreOverlay;
       version = "8.0.0";

--- a/default.nix
+++ b/default.nix
@@ -167,7 +167,7 @@ let
                         evalBaseExtensionsWith
                           pd.baseExtensions
                           (evalDependenciesBaseExtensions pd.dependencies initialBase)
-                          pd.components
+                          pd.components.nedrylandComponents
                       )
                       dependencies);
 

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670700605,
-        "narHash": "sha256-5dlpATkcyITpdtMflhltuD+A3RNpsVI1Mb+dtKkll6Y=",
+        "lastModified": 1672580127,
+        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7b9eeb856cbf976482fa8d1cb295ea03fb3e1277",
+        "rev": "0874168639713f547c05947c76124f78441ea46c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,23 +44,16 @@
           };
 
           devShells.docs = internalNedryland.docs;
+          checks.default = builtins.derivation {
+            inherit system;
+            name = "all-tests";
+            builder = "${pkgs.bash}/bin/bash";
+            args = [ "-c" ''${pkgs.coreutils}/bin/touch $out'' ];
+            tests = builtins.filter (x: x != { })
+              (import ./test.nix {
+                inherit pkgs;
+              }).all;
+          };
         }
-      ) // (
-      let
-        system = "x86_64-linux";  # TODO eachDefaultSystem does not work correctly for check
-        pkgs = nixpkgs.legacyPackages."${system}";
-      in
-      {
-        checks."${system}".default = builtins.derivation {
-          inherit system;
-          name = "all-tests";
-          builder = "${pkgs.bash}/bin/bash";
-          args = [ "-c" ''${pkgs.coreutils}/bin/touch $out'' ];
-          tests = builtins.filter (x: x != { })
-            (import ./test.nix {
-              inherit pkgs;
-            }).all;
-        };
-      }
-    );
+      );
 }

--- a/test.nix
+++ b/test.nix
@@ -21,6 +21,8 @@ let
     componentFnsTest = builtins.trace "📦 Running componentFns tests." import ./test/components.nix pkgs.lib.assertMsg;
   };
 in
-(tests // {
-  all = builtins.attrValues tests;
-})
+builtins.trace
+  "📠 Running tests for buildPlatform ${pkgs.system}"
+  (tests // {
+    all = builtins.attrValues tests;
+  })

--- a/test/docs.nix
+++ b/test/docs.nix
@@ -1,24 +1,27 @@
 pkgs: docMatrix:
-pkgs.runCommand "test-doc-out-path" { outPath = docMatrix.awesomeClient.docs; jason = pkgs.jq; } ''
-  set -e
-  touch $out
-  assertPathExists() {
-    if [ ! -d "$1" ]; then
-      echo "$2"
-      exit 101
-    fi
-  }
+if pkgs.lib.versionAtLeast pkgs.lib.version "22.11" || pkgs.system != "x86_64-darwin" then
+  pkgs.runCommand "test-doc-out-path" { outPath = docMatrix.awesomeClient.docs; jason = pkgs.jq; } ''
+    set -e
+    touch $out
+    assertPathExists() {
+      if [ ! -d "$1" ]; then
+        echo "$2"
+        exit 101
+      fi
+    }
 
-  assertEq() {
-    if [ "$1" != "$2" ]; then
-      echo "$3"
-      exit 102
-    fi
-  }
+    assertEq() {
+      if [ "$1" != "$2" ]; then
+        echo "$3"
+        exit 102
+      fi
+    }
 
-  assertPathExists "$outPath/share/doc/client-docs/manuel" "Expected name and type override to work"
-  assertPathExists "$outPath/share/doc/awesome-client/about" "Expected default name to be component name and default type to be set key"
+    assertPathExists "$outPath/share/doc/client-docs/manuel" "Expected name and type override to work"
+    assertPathExists "$outPath/share/doc/awesome-client/about" "Expected default name to be component name and default type to be set key"
 
-  local sharks=$($jason/bin/jq -r .sharks "$outPath/share/doc/awesome-client/metadata.json")
-  assertEq $sharks "5" "Expected doc set metadata to propagate to metadata.json (sharks should be 5)"
-''
+    local sharks=$($jason/bin/jq -r .sharks "$outPath/share/doc/awesome-client/metadata.json")
+    assertEq $sharks "5" "Expected doc set metadata to propagate to metadata.json (sharks should be 5)"
+  ''
+else
+  builtins.trace "The watchdog Python package (used by mkdocs) is broken in nixpkgs < 22.11 on macOS(x86), skipping test" { }


### PR DESCRIPTION
It used the components-derivation from the dependent project instead of
the actual attribute set. This was changed with Nedryland 8.0.0.

Add a check for the oldest supported nixpkgs version.

Also, some small fixes to tests.