### PR TITLE
🐛 Fix shell text on missing target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Help message for entering a shell without a proper target.
+
 ## [8.1.0] - 2023-01-13
 
 ### Added

--- a/shells.nix
+++ b/shells.nix
@@ -135,9 +135,10 @@ in
                   derivationShells."${config.defaultTarget}" or
                     (mkShell {
                       shellHook = ''
-                        🐚 Could not decide on a default shell for component "${component.name}"
-                        🎯 Available targets are: ${builtins.concatStringsSep ", " (builtins.attrNames derivationShells)}
-                        exit 1
+                        echo '
+                          🐚 Could not decide on a default shell for component "${component.name}"
+                          🎯 Available targets are: ${builtins.concatStringsSep ", " (builtins.attrNames derivationShells)}'
+                          exit 1
                       '';
                     });
 
@@ -148,9 +149,9 @@ in
             ({
               docs = mkShell {
                 shellHook = ''
-                  Invalid shell "docs"!
+                  echo 'Invalid shell "docs"!
                   🐚 The docs attribute is just the combination of the sub-targets.
-                  🎯 Available sub-targets are: ${builtins.concatStringsSep ", " (builtins.attrNames (lib.filterAttrs (_: lib.isDerivation) component.docs.passthru))}
+                  🎯 Available sub-targets are: ${builtins.concatStringsSep ", " (builtins.attrNames (lib.filterAttrs (_: lib.isDerivation) component.docs.passthru))}'
                   exit 1
                 '';
                 passthru = toShells (component.docs // { inherit (component) name path; });


### PR DESCRIPTION
When switching from builtins.abort to a shell that prints and exits the echo command was omitted resulting in the shell trying to execute the text as code.