### PR TITLE
🐛 Fix deployment for component sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- Deployment and docs special treatment is not given to component sets.
+- Target linkfarms contains the full path to the target.
+
 ## [8.1.2] - 2023-01-17
 
 ### Fixed

--- a/component.nix
+++ b/component.nix
@@ -15,7 +15,7 @@ rec {
           component =
             (attrs // {
               inherit name path nedrylandType;
-            } // (pkgs.lib.optionalAttrs (attrs ? deployment && attrs.deployment != { }) {
+            } // (pkgs.lib.optionalAttrs (nedrylandType != "component-set" && attrs ? deployment && attrs.deployment != { }) {
               # the deploy target is simply the sum of everything
               # in the deployment set
               deploy = mkCombinedDeployment "${name}-deploy" attrs.deployment;
@@ -23,7 +23,7 @@ rec {
                 (pkgs.linkFarm
                   "${name}-deployment"
                   (pkgs.lib.mapAttrsToList (name: path: { inherit name path; }) attrs.deployment));
-            }) // (pkgs.lib.optionalAttrs (attrs ? docs && !pkgs.lib.isDerivation attrs.docs) {
+            }) // (pkgs.lib.optionalAttrs (nedrylandType != "component-set" && attrs ? docs && !pkgs.lib.isDerivation attrs.docs) {
               # the docs target is a symlinkjoin of all sub-derivations
               docs =
                 let

--- a/default.nix
+++ b/default.nix
@@ -254,7 +254,7 @@ let
                   (builtins.listToAttrs (builtins.map
                     (value: {
                       inherit value;
-                      name = builtins.concatStringsSep "." value.accessPath;
+                      name = builtins.concatStringsSep "." (value.accessPath ++ [ target ]);
                     })
                     drvs)))
               (pkgs'.lib.zipAttrs
@@ -270,7 +270,8 @@ let
                           (
                             name: value:
                               name != "_default" &&
-                              (pkgs'.lib.isDerivation value)
+                              (pkgs'.lib.isDerivation value) &&
+                              !(value.isNedrylandComponent or false)
                           )
                           comp.componentAttrs)
                     )
@@ -323,9 +324,9 @@ let
             componentSet;
 
           # y-axis
-          targets = (extendedBase.mkComponentSet
+          targets = extendedBase.mkComponentSet
             "targets"
-            allTargets) // allTargets;
+            allTargets;
 
           # matrix
           matrix = componentSet // { inherit targets; };


### PR DESCRIPTION
Make suer component sets do not get special treatment for targets
`deployment` and `docs`. It does not make sense for them to have any of those.