### PR TITLE
Linkfarm updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Components can take `passthru`, they are exposed on the component like
+  mkDerivation does, but not sent to the linkfarm. This can be useful to have
+  expensive properties on the component accessible without adding a lot of eval cost.
+
 ## [8.2.1] - 2023-01-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mkDerivation does, but not sent to the linkfarm. This can be useful to have
   expensive properties on the component accessible without adding a lot of eval cost.
 
+### Changed
+- Component linkFarms does not shadow any attributes, user added attributes takes precedence.
+
 ## [8.2.1] - 2023-01-27
 
 ### Fixed

--- a/component.nix
+++ b/component.nix
@@ -15,7 +15,7 @@ rec {
           component =
             (attrs // {
               inherit name path nedrylandType;
-            } // (pkgs.lib.optionalAttrs (nedrylandType != "component-set" && attrs ? deployment && attrs.deployment != { }) {
+            } // (pkgs.lib.optionalAttrs (nedrylandType != "component-set" && attrs ? deployment) {
               # the deploy target is simply the sum of everything
               # in the deployment set
               deploy = mkCombinedDeployment "${name}-deploy" attrs.deployment;
@@ -62,6 +62,7 @@ rec {
             (pkgs.lib.mapAttrsToList
               (name: path: { inherit name path; })
               (pkgs.lib.filterAttrs (_: pkgs.lib.isDerivation) component)))
+          // (component.passthru or { })
           // {
           isNedrylandComponent = true;
           overrideAttrs = f: mkComponentInner (attrs // (f component));

--- a/component.nix
+++ b/component.nix
@@ -55,21 +55,22 @@ rec {
             docsRequirement)
           ''Projects config demands type "${component.nedrylandType}" to have at least: ${builtins.concatStringsSep ", " docsRequirement}.
           "${component.name}" has: ${builtins.concatStringsSep "," (builtins.attrNames attrs.docs or { })}.'';
-        (component
-          //
+        (
           (pkgs.linkFarm
             name
             (pkgs.lib.mapAttrsToList
               (name: path: { inherit name path; })
               (pkgs.lib.filterAttrs (_: pkgs.lib.isDerivation) component)))
+          // (builtins.removeAttrs component [ "passthru" ])
           // (component.passthru or { })
           // {
-          isNedrylandComponent = true;
-          overrideAttrs = f: mkComponentInner (attrs // (f component));
-          override = mkComponentInner;
-          componentAttrs = component;
-          nedrylandComponents = pkgs.lib.filterAttrs (_: c: c.isNedrylandComponent or false) component;
-        });
+            isNedrylandComponent = true;
+            overrideAttrs = f: mkComponentInner (attrs // (f component));
+            override = mkComponentInner;
+            componentAttrs = component;
+            nedrylandComponents = pkgs.lib.filterAttrs (_: c: c.isNedrylandComponent or false) component;
+          }
+        );
     in
     mkComponentInner;
 


### PR DESCRIPTION
In order to speed up project evaluation, attributes can now be put in passthru on the component and those are not added to the linkFarm. Also added a commit which changes order of precedence of the linkFarm vs user attributes.