### PR TITLE
🐛 ⚡ Fix comprecurse througf comp sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- collectComponentsRecursive uses nedrylandComponents if it exists, avoiding
+  some evaluation of other attributes.
+
 ## [Unreleased]
 
 ## [8.2.1] - 2023-01-27

--- a/component.nix
+++ b/component.nix
@@ -103,7 +103,10 @@ rec {
               [ ];
         in
         set:
-        builtins.concatMap (name: g name (builtins.getAttr name set)) (builtins.attrNames set);
+        let
+          componentSet = set.nedrylandComponents or set;
+        in
+        builtins.concatMap (name: g name (builtins.getAttr name componentSet)) (builtins.attrNames componentSet);
     in
     recurse [ ];
 }

--- a/test/components.nix
+++ b/test/components.nix
@@ -48,6 +48,23 @@ let
       };
     };
   };
+
+  project4 = {
+    componentSet1 = rec {
+      isNedrylandComponent = true;
+      component1 = {
+        isNedrylandComponent = true;
+      };
+      component2 = {
+        isNedrylandComponent = true;
+      };
+      component3 = {
+        isNedrylandComponent = true;
+      };
+      nedrylandComponents = { inherit component1 component2; };
+    };
+  };
+
   removeAccessPath = builtins.map (c: builtins.removeAttrs c [ "accessPath" ]);
 in
 assertMsg:
@@ -79,4 +96,19 @@ assert assertMsg
     component2 = { name = "no-name"; path = [ "component2" ]; };
   })
   "mapComponentRecursive did not produce the expected result";
+
+# Only collect components in nedrylandComponents if it exists.
+assert assertMsg
+  (removeAccessPath
+    (
+      componentFns.collectComponentsRecursive project4) == (with project4; [
+    componentSet1
+    componentSet1.component1
+    componentSet1.component2
+  ]
+  )
+  )
+  "Expected collectComponentsRecursive to only recurse through nedrylandComponents.";
+
+# Return nothing so signal tests passed.
 { }


### PR DESCRIPTION
collectComponentsRecursive and mapComponentsRecursive ignored component-set type which was not wanted. Now it goes through those sets.