### PR TITLE
🐛 Fix override on component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- override on mkComponent didn't override, just called the mkComponent with only
+  the new arguments.
+
 ## [8.3.0] - 2023-02-08
 
 ### Fixed

--- a/component.nix
+++ b/component.nix
@@ -66,7 +66,7 @@ rec {
           // {
             isNedrylandComponent = true;
             overrideAttrs = f: mkComponentInner (attrs // (f component));
-            override = mkComponentInner;
+            override = arg: mkComponentInner (attrs // arg);
             componentAttrs = component;
             nedrylandComponents = pkgs.lib.filterAttrs (_: c: c.isNedrylandComponent or false) component;
           }


### PR DESCRIPTION
override didn't combine the old input with the new, it was just an alias for calling the original function.