### PR TITLE
🐛 Fix shellcheck not handling spaces in file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- checks.shellcheck can now handle files with spaces in the names.
+
 ## [8.3.1] - 2023-04-21
 
 ### Fixed

--- a/ci/shellcheck
+++ b/ci/shellcheck
@@ -6,6 +6,7 @@ color="auto"
 [ -n "${NEDRYLAND_CHECK_COLOR:-}" ] && color="always"
 
 lintFiles() {
+    local IFS=$'\n'
     exitCode=0
     # shellcheck disable=SC2086
     while mapfile -t -n 50 shellFiles && ((${#shellFiles[@]})); do


### PR DESCRIPTION
Default IFS splits on any whitespace character, <<< would split on space as well as newline.