### PR TITLE
🐛 Fix shells for docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - checks.shellcheck can now handle files with spaces in the names.
+- Shells for docs
 
 ## [8.3.1] - 2023-04-21
 


### PR DESCRIPTION
We changed the structure the data when creating shells. We did however not change it where we manually call mkShellForComponent for docs. This caused an error saying that it was missing the attribute `componentAttrs`.

Changed the data for the docs to conform with the new data structure.