### PR TITLE
🐛 Use the same pid file name everywhere for mdbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- mdbook shell commands now finds the running process correctly, making the stop
+  and open commands work.
+
 ## [8.3.2] - 2023-06-09
 
 ### Fixed

--- a/documentation/mdbook-run.bash
+++ b/documentation/mdbook-run.bash
@@ -25,7 +25,7 @@ if ! ps -p $servePid >/dev/null; then
     exit 1
 fi
 
-echo $servePid > ./run.pid
-echo "$servePort" >> ./run.pid
+echo $servePid > ./mdbook.pid
+echo "$servePort" >> ./mdbook.pid
 echo ""
 echo "Mdbook running on $servePort"


### PR DESCRIPTION
The command creating the pid file used another file name than the commands using it. Decided to stick to mdbook.pid instead of run.pid to make more obvious to the user what it's for.