### PR TITLE
🐛 Make base.mkDerivation take pname + version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mdbook shell commands now finds the running process correctly, making the stop
   and open commands work.
 - Error on github actions on macos, fixed by updating install-nix-action version.
+- base.mkDerivation could not take pname + version instead of name, like stdenv.mkDerivation.
 
 ## [8.3.2] - 2023-06-09
 

--- a/default.nix
+++ b/default.nix
@@ -85,7 +85,10 @@ let
                       input
                   );
 
-                mkDerivation = attrs@{ name, stdenv ? pkgs'.stdenv, ... }:
+                mkDerivation = attrs@{ stdenv ? pkgs'.stdenv, ... }:
+                  assert pkgs'.lib.assertMsg
+                    (!(attrs ? name) -> attrs ? pname && attrs ? version)
+                    "mkDerivation missing required argument name, alternatively supply pname and version.";
                   let
                     customerFilter = src:
                       let
@@ -101,7 +104,7 @@ let
                           {
                             inherit (attrs) src;
                             filter = customerFilter attrs.src attrs.srcFilter;
-                            name = "${name}-source";
+                            name = "${attrs.name or attrs.pname}-source";
                           } else pkgs'.gitignoreSource attrs.src;
                   in
                   stdenv.mkDerivation ((builtins.removeAttrs attrs [ "stdenv" "srcFilter" "shellCommands" ]) //


### PR DESCRIPTION
stdenv.mkDerivation can take pname and version to construct name, lets not block anyone using base.mkDerivation from doing the same. Added a custom assert message because the message from the nested functions inside pkgs becomes a bit confusing.