### PR TITLE
🔨 Don't use mkShell for component's shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- shells are now created on the derivation directly instead of using pkgs.mkShell.
+
 ## [8.3.3] - 2023-09-26
 
 ### Fixed


### PR DESCRIPTION
Only use it to generate warning shells for missing/bad targets. This makes shells a bit simpler and avoids unnecessary and confusing extra steps with unexpected consequences.