### PR TITLE
✨ Add support for nixpkgs up to 23.11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ on:
         default: true
         type: boolean
 
-      nix-lint:
+      nixlint:
         description: "If linting of nix files should run, default true."
         default: true
         type: boolean
@@ -63,7 +63,7 @@ jobs:
 
   lint:
     name: Lint Nix Expressions 🦕 📝 👀
-    if: ${{ inputs.nix-lint }}
+    if: ${{ inputs.nixlint }}
     runs-on: ubuntu-latest
 
     steps:
@@ -75,7 +75,7 @@ jobs:
         install_url: https://releases.nixos.org/nix/nix-${{ inputs.nix-version }}/install
 
     - name: Lint Nix files 🦕 📝 👀
-      run: nix run .#checks.nix-lint
+      run: nix run .#checks.nixlint
 
   actionlint:
     name: Lint Github Actions 🐙 🐱 🎬

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for nixpkgs up to 23.11
+
+### Changed
+- The default linter is now statix instead of nix-lint. The name of the nix attribute and
+  script is also changed from `nix-lint` to `nixlint` to be consistent with other linting
+  tools.
+
 ### Fixed
 - Shells were assuming that the `name` attribute always existed on derivations.
   This is not always true and `pname` can now also be used.

--- a/ci/actionlint
+++ b/ci/actionlint
@@ -3,6 +3,8 @@
 
 set -uo pipefail
 
+@preamble@
+
 # the two ignores are for an older version of the actionlint tool
 # TODO: check version?
 

--- a/ci/check
+++ b/ci/check
@@ -5,6 +5,8 @@ set -uo pipefail
 shopt -s nullglob
 shopt -s extglob
 
+@preamble@
+
 export NEDRYLAND_CHECK_COLOR=1
 emoji_index=0
 exit_code=0

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -4,7 +4,7 @@
 , mktemp
 , shellcheck
 , shfmt
-, nix-linter
+, statix
 , bash
 , gnused
 , python3
@@ -17,24 +17,30 @@ runCommandLocal "check"
   mktemp = "${mktemp}/bin/mktemp";
   shellcheck = "${shellcheck}/bin/shellcheck";
   shfmt = "${shfmt}/bin/shfmt";
-  nixLinter = "${nix-linter}/bin/nix-linter";
+  nixLinter = "${statix}/bin/statix";
   bash = "${bash}/bin/bash";
   sed = "${gnused}/bin/sed";
   pyflakes = "${python3.pkgs.pyflakes}/bin/pyflakes";
   actionlint = "${actionlint}/bin/actionlint";
+  preamble = ''
+    if [[ ",''${NEDRYLAND_NO_USE_CHECK_FILES:-}," =~ ",$(basename "$0")," ]]; then
+      echo "forcing file list off for tool \"$(basename "$0")\""
+      unset NEDRYLAND_CHECK_FILES
+    fi
+  '';
 }
   (builtins.foldl'
     (buildScript: inputScript:
-      let
-        outputScript = "${(builtins.placeholder "out")}/bin/${builtins.head (builtins.split "\\\." (builtins.baseNameOf inputScript))}";
-      in
-      ''
-        ${buildScript}
-        mkdir -p "$(dirname "${outputScript}")"
-        substituteAll ${inputScript} ${outputScript}
-        chmod +x ${outputScript}
-      ''
+    let
+      outputScript = "${(builtins.placeholder "out")}/bin/${builtins.head (builtins.split "\\\." (builtins.baseNameOf inputScript))}";
+    in
+    ''
+      ${buildScript}
+      mkdir -p "$(dirname "${outputScript}")"
+      substituteAll ${inputScript} ${outputScript}
+      chmod +x ${outputScript}
+    ''
     )
     ""
-    [ ./nixfmt ./shellcheck ./nix-lint ./check ./actionlint ]
+    [ ./nixfmt ./shellcheck ./nixlint ./check ./actionlint ]
   )

--- a/ci/nixfmt
+++ b/ci/nixfmt
@@ -4,6 +4,8 @@
 set -uo pipefail
 color="auto"
 
+@preamble@
+
 [ -n "${NEDRYLAND_CHECK_COLOR:-}" ] && color="always"
 
 check="--check"

--- a/ci/nixlint
+++ b/ci/nixlint
@@ -1,16 +1,19 @@
 #! @bash@
 # shellcheck shell=bash
 
-set -uo pipefail
+@preamble@
 
+set -uo pipefail
 if [ $# -eq 0 ]; then
     if [ -z "${NEDRYLAND_CHECK_FILES:-}" ]; then
-        @nixLinter@ -r .
+        @nixLinter@ check .
         exit $?
     else
         exitCode=0
-        while mapfile -t -n 50 nix_files && ((${#nix_files[@]})); do
-            if ! @nixLinter@ "${nix_files[@]}"; then
+        # statix cannot support multiple files
+        # https://github.com/nerdypepper/statix/issues/69
+        while mapfile -t -n 1 nix_files && ((${#nix_files[@]})); do
+            if ! @nixLinter@ check "${nix_files[@]}"; then
                 exitCode=1;
             fi
         done <<< "$(grep ".nix$" < "$NEDRYLAND_CHECK_FILES")"

--- a/ci/shellcheck
+++ b/ci/shellcheck
@@ -2,6 +2,9 @@
 # shellcheck shell=bash
 
 set -uo pipefail
+
+@preamble@
+
 color="auto"
 [ -n "${NEDRYLAND_CHECK_COLOR:-}" ] && color="always"
 

--- a/component.nix
+++ b/component.nix
@@ -13,16 +13,16 @@ rec {
       mkComponentInner = attrs@{ name, nedrylandType ? "component", ... }:
         let
           component =
-            (attrs // {
+            attrs // {
               inherit name path nedrylandType;
             } // (pkgs.lib.optionalAttrs (nedrylandType != "component-set" && attrs ? deployment) {
               # the deploy target is simply the sum of everything
               # in the deployment set
               deploy = mkCombinedDeployment "${name}-deploy" attrs.deployment;
               deployment = attrs.deployment //
-                (pkgs.linkFarm
-                  "${name}-deployment"
-                  (pkgs.lib.mapAttrsToList (name: path: { inherit name path; }) attrs.deployment));
+              (pkgs.linkFarm
+                "${name}-deployment"
+                (pkgs.lib.mapAttrsToList (name: path: { inherit name path; }) attrs.deployment));
             }) // (pkgs.lib.optionalAttrs (nedrylandType != "component-set" && attrs ? docs && !pkgs.lib.isDerivation attrs.docs) {
               # the docs target is a symlinkjoin of all sub-derivations
               docs =
@@ -41,7 +41,7 @@ rec {
                     echo '${builtins.toJSON attrsWithResolvedDocDrvs}' > $out/share/doc/${name}/metadata.json
                   '';
                 };
-            }));
+            });
 
           docsRequirement = (parseConfig {
             key = "docs";
@@ -98,7 +98,7 @@ rec {
             if value.isNedrylandComponent or false then
               [
                 ({
-                  accessPath = (path ++ [ name ]);
+                  accessPath = path ++ [ name ];
                 } // value)
               ] ++ (recurse (path ++ [ name ]) value)
             else

--- a/documentation/default.nix
+++ b/documentation/default.nix
@@ -15,7 +15,7 @@ in
 
 builtins.mapAttrs
   (_: f: attrs: {
-    docfunction = (name: type: (f ({ inherit name type; } // attrs)));
+    docfunction = name: type: (f ({ inherit name type; } // attrs));
   })
 rec {
   mkProjectDocs =

--- a/examples/dependencies/child/flake.lock
+++ b/examples/dependencies/child/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -17,16 +20,16 @@
     },
     "pkgs": {
       "locked": {
-        "lastModified": 1671313200,
-        "narHash": "sha256-itZTrtHeDJjV696+ur0/TzkTqb5y3Eb57WRLRPK3rwA=",
+        "lastModified": 1703992652,
+        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0938d73bb143f4ae037143572f11f4338c7b2d1c",
+        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "pkgs": "pkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/examples/dependencies/child/flake.nix
+++ b/examples/dependencies/child/flake.nix
@@ -2,8 +2,8 @@
   description = "Example project demonstrating project dependencies.";
 
   inputs = {
-    pkgs.url = github:NixOS/nixpkgs/nixos-22.11;
-    flake-utils.url = github:numtide/flake-utils;
+    pkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { pkgs, flake-utils, ... }:

--- a/examples/dependencies/father/project.nix
+++ b/examples/dependencies/father/project.nix
@@ -2,7 +2,7 @@
 (nedryland { inherit pkgs; }).mkProject {
   name = "dep-example-father";
 
-  components = {}: { };
+  components = _: { };
 
   baseExtensions = [
     ./extensions/mkfather.nix

--- a/examples/documentation/flake.lock
+++ b/examples/documentation/flake.lock
@@ -1,24 +1,58 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "pkgs": {
       "locked": {
-        "lastModified": 1670856834,
-        "narHash": "sha256-GitzxDZo7385SBoMpHRA9NBAhBh/5TBK8ptpQFAoMYc=",
+        "lastModified": 1703992652,
+        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "06278c77b5d162e62df170fec307e83f1812d94b",
+        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "pkgs": "pkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/examples/documentation/flake.nix
+++ b/examples/documentation/flake.nix
@@ -2,8 +2,8 @@
   description = "Example project demonstrating documentation capabilities.";
 
   inputs = {
-    pkgs.url = github:NixOS/nixpkgs/nixos-22.11;
-    flake-utils.url = github:numtide/flake-utils;
+    pkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { pkgs, flake-utils, ... }:

--- a/examples/hello/clients/hello/hello.nix
+++ b/examples/hello/clients/hello/hello.nix
@@ -5,7 +5,7 @@ base.mkClient rec{
   name = "hello";
   version = "1.0.0";
 
-  package = ((writeScriptBin name ''
+  package = (writeScriptBin name ''
     set -e
     translation=$(${greeting.lib}/bin/greetinglib $1)
     echo "Hello in $1 is \"$translation\""
@@ -35,6 +35,6 @@ base.mkClient rec{
         '';
       };
     };
-  }));
+  });
 
 }

--- a/examples/hello/flake.lock
+++ b/examples/hello/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -17,16 +20,16 @@
     },
     "pkgs": {
       "locked": {
-        "lastModified": 1670856834,
-        "narHash": "sha256-GitzxDZo7385SBoMpHRA9NBAhBh/5TBK8ptpQFAoMYc=",
+        "lastModified": 1703992652,
+        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "06278c77b5d162e62df170fec307e83f1812d94b",
+        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "pkgs": "pkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/examples/hello/flake.nix
+++ b/examples/hello/flake.nix
@@ -2,8 +2,8 @@
   description = "Example project demonstrating simple components.";
 
   inputs = {
-    pkgs.url = github:NixOS/nixpkgs/nixos-22.11;
-    flake-utils.url = github:numtide/flake-utils;
+    pkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { pkgs, flake-utils, ... }:

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -17,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1704295289,
+        "narHash": "sha256-9WZDRfpMqCYL6g/HNWVvXF0hxdaAgwgIGeLYiOhmes8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "b0b2c5445c64191fd8d0b31f2b1a34e45a64547d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,14 @@
 {
   description = "Nedryland is a collection of utilities and a build system for declaring, building and deploying microservice solutions.";
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
-  inputs.flake-utils.url = github:numtide/flake-utils;
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = nixpkgs.legacyPackages."${system}";
-          internalNedryland = (import ./default.nix { inherit pkgs; });
+          internalNedryland = import ./default.nix { inherit pkgs; };
         in
         {
           lib = import ./.;
@@ -23,7 +23,7 @@
           apps = {
             checks = rec {
               type = "app";
-              program = all.program;
+              inherit (all) program;
 
               nixfmt = {
                 type = "app";
@@ -33,9 +33,9 @@
                 type = "app";
                 program = "${internalNedryland.checks}/bin/shellcheck";
               };
-              nix-lint = {
+              nixlint = {
                 type = "app";
-                program = "${internalNedryland.checks}/bin/nix-lint";
+                program = "${internalNedryland.checks}/bin/nixlint";
               };
               all = {
                 type = "app";

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,0 @@
-(builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/925ae0dee63cf2c59533a6258340812e5643428a.tar.gz)

--- a/shell-commands.nix
+++ b/shell-commands.nix
@@ -48,8 +48,8 @@ let
         ${shellCommandHelpText (builtins.mapAttrs
         (_: value:
           {
-            description = (if builtins.isAttrs value then value.description or "" else "");
-            args = (if builtins.isAttrs value then value.args or "" else "");
+            description = if builtins.isAttrs value then value.description or "" else "";
+            args = if builtins.isAttrs value then value.args or "" else "";
           }
         )
           (lib.filterAttrs (_: value:

--- a/shells.nix
+++ b/shells.nix
@@ -51,9 +51,9 @@ in
                     #
                     # Priority of nativeBuildInputs then becomes:
                     #  1. nativeBuildInputs
-                    #  2. checkInputs/installCheckInputs
-                    #  3. shellInputs
-                    #  4. shellCommands
+                    #  2. shellInputs
+                    #  3. shellCommands
+                    #  4. nativeCheckInputs/checkInputs/installCheckInputs
                     nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ]
                     ++ oldAttrs.passthru.shellInputs or [ ]
                     ++ oldAttrs.shellInputs or [ ]
@@ -79,7 +79,7 @@ in
                       fi
 
                       # This is for `nix develop` and flakes.
-                      if [[ "$componentDir" == /nix/store/* ]]; then
+                      if [[ "$componentDir" =~ ^/nix/store/.*$ ]]; then
                         git_root=$(${git}/bin/git rev-parse --show-toplevel)
                         target_relative="$(echo "$componentDir" | cut -d/ -f 5-)"
                         componentDir="$git_root/$target_relative"
@@ -123,7 +123,7 @@ in
         defaultShell.overrideAttrs (_: {
           passthru = componentShellsAndSubComponents // lib.optionalAttrs
             (component ? docs)
-            ({
+            {
               docs = mkShell {
                 shellHook = ''
                   echo -e '\x1b[31mInvalid shell "docs"!\x1b[0m'
@@ -138,7 +138,7 @@ in
                   }
                   (pth ++ [ "docs" ]);
               };
-            });
+            };
         })
       )
   )

--- a/target-setup/default.nix
+++ b/target-setup/default.nix
@@ -14,11 +14,12 @@ let
     key = "components";
     structure = pkgs.lib.mapAttrs (_: _: null) (variableQueries // variables);
   });
+  depsAttr = if pkgs.lib.versionOlder pkgs.lib.version "23.05pre-git" then "deps" else "propagatedBuildInputs";
 in
 pkgs.makeSetupHook
 {
   name = "target-setup-${builtins.replaceStrings [ " " ] [ "-" ] name}";
-  deps = [ pkgs.envsubst pkgs.tree ];
+  "${depsAttr}" = [ pkgs.envsubst pkgs.tree ];
   substitutions = {
     inherit typeName showTemplate initCommands;
     envsubst = "${pkgs.envsubst}/bin/envsubst";

--- a/test/components.nix
+++ b/test/components.nix
@@ -71,7 +71,7 @@ assertMsg:
 assert assertMsg
   (removeAccessPath
     (componentFns.collectComponentsRecursive project1)
-  == (with project1; [ component1 component2 ]))
+    == (with project1; [ component1 component2 ]))
   "collectComponentsRecursive did not collect!";
 
 assert assertMsg


### PR DESCRIPTION
- Change linter from nix-lint to statix since the former is broken in 23.11 and seems somewhat unmaintained. Fix all lints as well.