### PR TITLE
🐛 Make checks.nixfmt work from everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `.#checks.nixfmt` can be run from everywhere when nixFiles are relative to project.
+
 ## [10.0.0] - 2024-02-06
 
 ### Added

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -9,6 +9,7 @@
 , gnused
 , python3
 , actionlint
+, git
 }:
 runCommandLocal "check"
 {
@@ -22,6 +23,7 @@ runCommandLocal "check"
   sed = "${gnused}/bin/sed";
   pyflakes = "${python3.pkgs.pyflakes}/bin/pyflakes";
   actionlint = "${actionlint}/bin/actionlint";
+  git = "${git}/bin/git";
   preamble = ''
     if [[ ",''${NEDRYLAND_NO_USE_CHECK_FILES:-}," =~ ",$(basename "$0")," ]]; then
       echo "forcing file list off for tool \"$(basename "$0")\""

--- a/ci/nixfmt
+++ b/ci/nixfmt
@@ -13,6 +13,10 @@ if [[ $* =~ (^|[[:space:]])+--fix([[:space:]]|$)+ ]]; then
     check=""
 fi
 
+if root="$(@git@ rev-parse --show-toplevel 2>/dev/null)"; then
+    cd "$root"
+fi
+
 if [ $# -eq 0 ] || [ -z "$check" ]; then
     exitCode=0
     files=()


### PR DESCRIPTION
If $nixFiles were expressed as relative to the root of the project, nixfmt would fail when ran from a sub directory. Now cd to the root first which will work for both relative and absolute paths.

Since nix (and thus we) have not committed to using flakes this instead uses git to find the root of the project.