### PR TITLE
🐛 Make mdbook run not rely on stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- ShellCommands not forwarding arguments to script when it's a file.
+
 ## [11.0.0] - 2026-06-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - ShellCommands not forwarding arguments to script when it's a file.
+- Mdbook's shellcommand `run` depended on mdbooks stdout.
+- Mdbook's shellcommand `run` didn't properly forwards arguments.
 
 ## [11.0.0] - 2026-06-05
 

--- a/documentation/mdbook-run.bash
+++ b/documentation/mdbook-run.bash
@@ -1,20 +1,44 @@
+#! @bash@
+# shellcheck shell=bash
+
+args=()
+port=0
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -p|--port)
+      port=$2
+      shift 2
+      ;;
+    -p=*|--port=*)
+      port="${1#*=}"
+      shift 1
+      ;;
+    -p*)
+      port="${1#-p}"
+      shift 1
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+
 ticker=("⢿" "⡿" "⣟" "⣯" "⣷" "⣾" "⣽" "⣻")
 tickerCount=0
 echo -n "📖 Starting mdbook... ${ticker[tickerCount]}"
 serveOutput=$(mktemp)
-mdbook serve --port "${1:-0}" "$@" 1>"$serveOutput" 2>&1 &
+mdbook serve --port "$port" "${args[@]}" 1>"$serveOutput" 2>&1 &
 servePid=$!
-servePort=""
-while ps -p $servePid >/dev/null && [ -z "$servePort" ]; do
-    if [ $((tickerCount % 2)) -eq 0 ]; then
-        servePort=$(sed -n -E 's/^.*listening on (.*)$/\1/p' "$serveOutput")
-    else
-        sleep 0.25
-    fi
-
+servePort=
+while [ -z "$servePort" ] && ps -p "$servePid" >/dev/null 2>&1; do
     tickerCount=$((tickerCount + 1))
     tickerCount=$((tickerCount % ${#ticker[@]}))
     echo -en "\b${ticker[tickerCount]}"
+    servePort=$(@procfd@ --pid $servePid --socket-type tcp --json \
+        | @jq@ 'first(.. | .local_port? | select(. != null))')
+    sleep 0.1
 done
 
 if ! ps -p $servePid >/dev/null; then
@@ -28,4 +52,4 @@ fi
 echo $servePid > ./mdbook.pid
 echo "$servePort" >> ./mdbook.pid
 echo ""
-echo "Mdbook running on $servePort"
+echo "Mdbook running on http://localhost:$servePort"

--- a/documentation/mdbook.nix
+++ b/documentation/mdbook.nix
@@ -27,12 +27,12 @@ base.mkDerivation (attrs // {
 
     run() {
       trap on_exit SIGQUIT EXIT SIGHUP
-      command run 0
+      command run "$@"
     }
 
     if checkRun; then
       echo ""
-      echo -e "🏃‍♀️ You seem to be running mdbook already at \e[93m$(tail -n 1 ./mdbook.pid)\e[0m, use \e[32mopen\e[0m to show it in your browser."
+      echo -e "🏃‍♀️ You seem to be running mdbook already at \e[93mhttp://localhost:$(tail -n 1 ./mdbook.pid)\e[0m, use \e[32mopen\e[0m to show it in your browser."
       echo ""
     else
       if [ -f ./mdbook.pid ]; then
@@ -44,7 +44,22 @@ base.mkDerivation (attrs // {
   '';
   shellCommands = {
     run = {
-      script = ./mdbook-run.bash;
+      script = pkgs.substitute {
+        name = "run-md-book";
+        src = ./mdbook-run.bash;
+        substitutions = [
+          "--subst-var-by"
+          "procfd"
+          "${pkgs.procfd}/bin/procfd"
+          "--subst-var-by"
+          "bash"
+          "${pkgs.bash}/bin/bash"
+          "--subst-var-by"
+          "jq"
+          "${pkgs.jq}/bin/jq"
+        ];
+        isExecutable = true;
+      };
       description = ''
         Preview the book and watches the book's src directory for changes, rebuilding the book and refreshing clients for each change.'';
     };

--- a/shell-commands.nix
+++ b/shell-commands.nix
@@ -41,7 +41,14 @@ let
 
         rm -rf "$envDir"
         set -euo pipefail
-        ${if builtins.isAttrs script then script.script or "" else script}
+        ${if builtins.isAttrs script then
+          if script ? script && script.script ? outPath then
+            "${script.script} \"$@\""
+          else
+            script.script or ""
+        else
+          script
+        }
       '')
       cmds) ++ [
       (writeShellScriptBin "shellHelp" ''


### PR DESCRIPTION
It is unreliably, like when mdbook updated how it serves and the output is different. Use procfd and jq instead to get the port from the pid.